### PR TITLE
feat: implement Phase 1 — onboarding and user profile

### DIFF
--- a/src/components/interest-selector.tsx
+++ b/src/components/interest-selector.tsx
@@ -1,0 +1,32 @@
+import { Badge } from "@/components/ui/badge";
+import { INTEREST_LABELS, INTEREST_OPTIONS } from "@/lib/validations/profile";
+
+interface InterestSelectorProps {
+	value: string[];
+	onChange: (value: string[]) => void;
+}
+
+export function InterestSelector({ value, onChange }: InterestSelectorProps) {
+	const toggle = (interest: string) => {
+		if (value.includes(interest)) {
+			onChange(value.filter((i) => i !== interest));
+		} else {
+			onChange([...value, interest]);
+		}
+	};
+
+	return (
+		<div className="flex flex-wrap gap-2">
+			{INTEREST_OPTIONS.map((interest) => {
+				const selected = value.includes(interest);
+				return (
+					<button key={interest} type="button" onClick={() => toggle(interest)}>
+						<Badge variant={selected ? "default" : "outline"}>
+							{INTEREST_LABELS[interest]}
+						</Badge>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/components/profile-form.tsx
+++ b/src/components/profile-form.tsx
@@ -1,0 +1,230 @@
+import { AtSign, Github, Globe, Linkedin, Twitter } from "lucide-react";
+import { useState } from "react";
+import { InterestSelector } from "@/components/interest-selector";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+	FieldSeparator,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	type CreateProfileInput,
+	createProfileSchema,
+	type UpdateProfileInput,
+	updateProfileSchema,
+} from "@/lib/validations/profile";
+
+interface ProfileFormProps {
+	mode: "create" | "edit";
+	defaultValues: Partial<CreateProfileInput> & { avatarUrl?: string | null };
+	onSubmit: (data: CreateProfileInput | UpdateProfileInput) => Promise<void>;
+	isSubmitting: boolean;
+}
+
+export function ProfileForm({
+	mode,
+	defaultValues,
+	onSubmit,
+	isSubmitting,
+}: ProfileFormProps) {
+	const [displayName, setDisplayName] = useState(
+		defaultValues.displayName ?? "",
+	);
+	const [bio, setBio] = useState(defaultValues.bio ?? "");
+	const [avatarUrl] = useState(defaultValues.avatarUrl ?? "");
+	const [website, setWebsite] = useState(defaultValues.website ?? "");
+	const [github, setGithub] = useState(defaultValues.github ?? "");
+	const [twitter, setTwitter] = useState(defaultValues.twitter ?? "");
+	const [linkedin, setLinkedin] = useState(defaultValues.linkedin ?? "");
+	const [interests, setInterests] = useState<string[]>(
+		defaultValues.interests ?? [],
+	);
+	const [errors, setErrors] = useState<Record<string, string>>({});
+
+	const handleSubmit = async () => {
+		const formData: Record<string, unknown> = {
+			displayName: displayName || null,
+			bio: bio || null,
+			avatarUrl: avatarUrl || null,
+			website: website || null,
+			github: github || null,
+			twitter: twitter || null,
+			linkedin: linkedin || null,
+			interests: interests.length > 0 ? interests : null,
+		};
+
+		if (mode === "create") {
+			formData.username = defaultValues.username;
+		}
+
+		const schema =
+			mode === "create" ? createProfileSchema : updateProfileSchema;
+		const result = schema.safeParse(formData);
+
+		if (!result.success) {
+			const fieldErrors: Record<string, string> = {};
+			for (const issue of result.error.issues) {
+				const field = issue.path[0];
+				if (field) {
+					fieldErrors[String(field)] = issue.message;
+				}
+			}
+			setErrors(fieldErrors);
+			return;
+		}
+
+		setErrors({});
+		await onSubmit(result.data);
+	};
+
+	return (
+		<FieldGroup>
+			<div className="flex items-center gap-4">
+				<Avatar className="size-16">
+					<AvatarImage src={avatarUrl} alt={defaultValues.username ?? ""} />
+					<AvatarFallback className="text-lg">
+						{(defaultValues.username ?? "?")[0]?.toUpperCase()}
+					</AvatarFallback>
+				</Avatar>
+				{mode === "create" && defaultValues.username && (
+					<div>
+						<p className="flex items-center gap-1 text-sm text-muted-foreground">
+							<AtSign className="size-3.5" />
+							{defaultValues.username}
+						</p>
+						<p className="text-xs text-muted-foreground">Herdado do Discord</p>
+					</div>
+				)}
+			</div>
+
+			<Field>
+				<FieldLabel htmlFor="displayName">Nome de exibicao</FieldLabel>
+				<FieldDescription>
+					Como voce quer ser chamado na plataforma
+				</FieldDescription>
+				<Input
+					id="displayName"
+					placeholder="Seu nome"
+					value={displayName}
+					onChange={(e) => setDisplayName(e.target.value)}
+					maxLength={100}
+				/>
+				{errors.displayName && <FieldError>{errors.displayName}</FieldError>}
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel htmlFor="bio">Bio</FieldLabel>
+				<FieldDescription>
+					Conte um pouco sobre voce (max. 280 caracteres)
+				</FieldDescription>
+				<Textarea
+					id="bio"
+					placeholder="O que voce esta construindo?"
+					value={bio}
+					onChange={(e) => setBio(e.target.value)}
+					maxLength={280}
+				/>
+				{errors.bio && <FieldError>{errors.bio}</FieldError>}
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel>Links</FieldLabel>
+				<FieldDescription>Seus perfis e site pessoal</FieldDescription>
+			</Field>
+
+			<Field>
+				<FieldLabel htmlFor="website">
+					<Globe className="size-4" />
+					Site
+				</FieldLabel>
+				<Input
+					id="website"
+					type="url"
+					placeholder="https://seusite.com"
+					value={website}
+					onChange={(e) => setWebsite(e.target.value)}
+				/>
+				{errors.website && <FieldError>{errors.website}</FieldError>}
+			</Field>
+
+			<Field>
+				<FieldLabel htmlFor="github">
+					<Github className="size-4" />
+					GitHub
+				</FieldLabel>
+				<Input
+					id="github"
+					placeholder="username"
+					value={github}
+					onChange={(e) => setGithub(e.target.value)}
+					maxLength={39}
+				/>
+				{errors.github && <FieldError>{errors.github}</FieldError>}
+			</Field>
+
+			<Field>
+				<FieldLabel htmlFor="twitter">
+					<Twitter className="size-4" />X / Twitter
+				</FieldLabel>
+				<Input
+					id="twitter"
+					placeholder="handle (sem @)"
+					value={twitter}
+					onChange={(e) => setTwitter(e.target.value)}
+					maxLength={15}
+				/>
+				{errors.twitter && <FieldError>{errors.twitter}</FieldError>}
+			</Field>
+
+			<Field>
+				<FieldLabel htmlFor="linkedin">
+					<Linkedin className="size-4" />
+					LinkedIn
+				</FieldLabel>
+				<Input
+					id="linkedin"
+					type="url"
+					placeholder="https://linkedin.com/in/seu-perfil"
+					value={linkedin}
+					onChange={(e) => setLinkedin(e.target.value)}
+				/>
+				{errors.linkedin && <FieldError>{errors.linkedin}</FieldError>}
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel>Areas de interesse</FieldLabel>
+				<FieldDescription>
+					Selecione as areas que mais te interessam
+				</FieldDescription>
+				<InterestSelector value={interests} onChange={setInterests} />
+				{errors.interests && <FieldError>{errors.interests}</FieldError>}
+			</Field>
+
+			<Button
+				type="button"
+				className="w-full"
+				size="lg"
+				disabled={isSubmitting}
+				onClick={handleSubmit}
+			>
+				{isSubmitting
+					? "Salvando..."
+					: mode === "create"
+						? "Completar perfil"
+						: "Salvar alteracoes"}
+			</Button>
+		</FieldGroup>
+	);
+}

--- a/src/data/constants/site.ts
+++ b/src/data/constants/site.ts
@@ -1,8 +1,8 @@
 export const SITE = {
-  name: "Rychillie",
-  url: "https://indiehackersbrasil.rychillie.workers.dev/",
-  auth: {
-    provider: "discord" as const,
-    callbackURL: "/",
-  },
+	name: "Indie Hacking Brasil",
+	url: "https://indiehackersbrasil.rychillie.workers.dev/",
+	auth: {
+		provider: "discord" as const,
+		callbackURL: "/",
+	},
 } as const;

--- a/src/data/services/profile.ts
+++ b/src/data/services/profile.ts
@@ -1,0 +1,126 @@
+import { createServerFn } from "@tanstack/react-start";
+import { and, eq } from "drizzle-orm";
+import { ensureSession } from "@/lib/auth/server";
+import { getDb } from "@/lib/db";
+import { account, profile } from "@/lib/db/schema";
+import type {
+	CreateProfileInput,
+	UpdateProfileInput,
+} from "@/lib/validations/profile";
+import {
+	createProfileSchema,
+	updateProfileSchema,
+} from "@/lib/validations/profile";
+
+export const getDiscordUsername = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const session = await ensureSession();
+		const db = getDb();
+
+		const discordAccount = await db.query.account.findFirst({
+			where: and(
+				eq(account.userId, session.user.id),
+				eq(account.providerId, "discord"),
+			),
+		});
+
+		if (!discordAccount?.accessToken) return null;
+
+		const res = await fetch("https://discord.com/api/users/@me", {
+			headers: { Authorization: `Bearer ${discordAccount.accessToken}` },
+		});
+
+		if (!res.ok) return null;
+
+		const discordProfile = (await res.json()) as { username: string };
+		return discordProfile.username;
+	},
+);
+
+export const getProfileByUserId = createServerFn({ method: "GET" }).handler(
+	async ({ data: userId }: { data: string }) => {
+		const db = getDb();
+		const result = await db.query.profile.findFirst({
+			where: eq(profile.userId, userId),
+		});
+		return result ?? null;
+	},
+);
+
+export const getProfileByUsername = createServerFn({ method: "GET" }).handler(
+	async ({ data: username }: { data: string }) => {
+		const db = getDb();
+		const result = await db.query.profile.findFirst({
+			where: eq(profile.username, username),
+		});
+		return result ?? null;
+	},
+);
+
+export const getCurrentUserProfile = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	const session = await ensureSession();
+	const db = getDb();
+	const result = await db.query.profile.findFirst({
+		where: eq(profile.userId, session.user.id),
+	});
+	return result ?? null;
+});
+
+export const createProfile = createServerFn({ method: "POST" }).handler(
+	async ({ data }: { data: CreateProfileInput }) => {
+		const parsed = createProfileSchema.parse(data);
+		const session = await ensureSession();
+		const db = getDb();
+
+		const existing = await db.query.profile.findFirst({
+			where: eq(profile.username, parsed.username),
+		});
+		if (existing) {
+			throw new Error("Username ja esta em uso");
+		}
+
+		const id = crypto.randomUUID();
+		await db.insert(profile).values({
+			id,
+			userId: session.user.id,
+			username: parsed.username,
+			displayName: parsed.displayName ?? null,
+			bio: parsed.bio ?? null,
+			avatarUrl: parsed.avatarUrl ?? session.user.image ?? null,
+			website: parsed.website ?? null,
+			github: parsed.github ?? null,
+			twitter: parsed.twitter ?? null,
+			linkedin: parsed.linkedin ?? null,
+			interests: parsed.interests ?? null,
+			isOnboardingComplete: true,
+		});
+
+		return { id, username: parsed.username };
+	},
+);
+
+export const updateProfile = createServerFn({ method: "POST" }).handler(
+	async ({ data }: { data: UpdateProfileInput }) => {
+		const parsed = updateProfileSchema.parse(data);
+		const session = await ensureSession();
+		const db = getDb();
+
+		await db
+			.update(profile)
+			.set({
+				displayName: parsed.displayName ?? null,
+				bio: parsed.bio ?? null,
+				avatarUrl: parsed.avatarUrl ?? null,
+				website: parsed.website ?? null,
+				github: parsed.github ?? null,
+				twitter: parsed.twitter ?? null,
+				linkedin: parsed.linkedin ?? null,
+				interests: parsed.interests ?? null,
+			})
+			.where(eq(profile.userId, session.user.id));
+
+		return { success: true };
+	},
+);

--- a/src/docs/conteudo-condicional.md
+++ b/src/docs/conteudo-condicional.md
@@ -1,0 +1,167 @@
+# Conteudo Condicional por Estado de Autenticacao
+
+## Visao Geral
+
+A plataforma exibe conteudo diferente dependendo do estado de autenticacao do usuario. Esse padrao e consistente em todas as rotas.
+
+### Estados Possiveis
+
+| Estado | Descricao | Como identificar |
+|--------|-----------|-----------------|
+| **Visitante** | Nao logado | `getSession()` retorna `null` |
+| **Autenticado sem perfil** | Logou via Discord mas nao completou onboarding | Sessao existe, mas `profile` nao existe ou `isOnboardingComplete = false` |
+| **Membro** | Logou e completou onboarding | Sessao existe e `profile.isOnboardingComplete = true` |
+| **Owner/Admin** | Membro com permissoes especiais no contexto | Membro + dono do recurso ou admin da plataforma |
+
+## Implementacao Tecnica
+
+### Server-side (beforeLoad)
+
+```typescript
+// Rota protegida — redireciona visitantes para a home
+export const Route = createFileRoute("/feed")({
+  beforeLoad: async () => {
+    const session = await getSession();
+    if (!session) {
+      throw redirect({ to: "/" });
+    }
+    return { session };
+  },
+  component: FeedPage,
+});
+```
+
+### Client-side (useSession)
+
+```typescript
+const { data: session, isPending } = authClient.useSession();
+
+if (isPending) return <Skeleton />;
+if (!session) return <LandingContent />;
+return <AuthenticatedContent />;
+```
+
+### Guard de Onboarding
+
+Apos verificar que o usuario esta autenticado, verificar se completou o onboarding. Se nao completou, redirecionar para `/onboarding`:
+
+```typescript
+// No beforeLoad de rotas que exigem perfil completo
+const session = await getSession();
+if (!session) throw redirect({ to: "/" });
+
+const profile = await getProfileByUserId(session.user.id);
+if (!profile || !profile.isOnboardingComplete) {
+  throw redirect({ to: "/onboarding" });
+}
+```
+
+---
+
+## Comportamento por Rota
+
+### `/` — Home
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Landing Page: apresentacao da comunidade, banner de chamada para o Discord, projetos em destaque, proximos eventos, numeros da comunidade |
+| **Autenticado sem perfil** | Redireciona para `/onboarding` |
+| **Membro** | Feed de atualizacoes (substitui a Landing Page completamente) |
+
+**Decisao tecnica**: a rota `/` usa renderizacao condicional no client (`useSession`) para alternar entre Landing Page e Feed, sem redirecionamento. Isso preserva a URL `/` para ambos os estados e melhora a experiencia de transicao.
+
+---
+
+### `/u/:username` — Perfil do Usuario
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Versao resumida e publica: nome, bio, avatar, lista de projetos. Botao "Entrar na comunidade" no lugar das interacoes sociais |
+| **Membro (vendo outro perfil)** | Perfil completo: bio, links, projetos, posts recentes, contadores (seguidores, seguindo). Botao "Seguir" |
+| **Membro (proprio perfil)** | Mesmo que acima + botao "Editar perfil" e acesso as configuracoes |
+
+**Nota**: se o `:username` nao existir, exibir pagina 404.
+
+---
+
+### `/projects` — Listagem de Projetos
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Lista de projetos com informacoes basicas (nome, descricao, categoria, status). Sem interacao (sem botoes de seguir/recomendar). Banner convidando a se cadastrar para interagir |
+| **Membro** | Lista completa com filtros por categoria e status. Botao "Criar projeto" no topo. Botoes de interacao (seguir, recomendar) em cada card |
+
+---
+
+### `/projects/:slug` — Pagina de Projeto
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Descricao, equipe (membros), recomendacoes (lista). Sem poder recomendar, comentar ou seguir. Banner de cadastro |
+| **Membro** | Tudo do visitante + botoes de recomendar, comentar, avaliar e seguir |
+| **Owner do projeto** | Tudo do membro + botao "Editar projeto", "Gerenciar colaboradores", "Excluir projeto" |
+
+---
+
+### `/events` — Listagem de Eventos
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Lista de proximos eventos em destaque e eventos passados. Acesso total — eventos sao conteudo publico |
+| **Membro** | Mesma experiencia do visitante (RSVP e funcionalidade futura) |
+| **Admin** | Mesma experiencia + botao "Criar evento" |
+
+**Nota**: eventos sao 100% publicos nesta versao. Nao ha diferenca de conteudo entre visitante e membro autenticado.
+
+---
+
+### `/events/:id` — Pagina de Evento
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Detalhes completos do evento: nome, data, formato, local/link, organizador, banner |
+| **Membro** | Mesma experiencia do visitante |
+| **Admin** | Mesma experiencia + botoes "Editar evento" e "Excluir evento" |
+
+---
+
+### `/feed` — Feed (URL propria)
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Redireciona para `/` (a Landing Page) |
+| **Autenticado sem perfil** | Redireciona para `/onboarding` |
+| **Membro** | Feed cronologico com posts BIP e comunicados. Filtro por tipo. Formulario de novo post |
+
+**Nota**: o Feed tambem aparece na Home (`/`) para membros autenticados. A rota `/feed` e um atalho direto, util para compartilhar ou bookmarkar.
+
+---
+
+### `/onboarding` — Fluxo de Criacao de Perfil
+
+| Estado | Comportamento |
+|--------|--------------|
+| **Visitante** | Redireciona para `/` (precisa logar primeiro) |
+| **Autenticado sem perfil** | Formulario multi-step de criacao de perfil |
+| **Membro (perfil completo)** | Redireciona para `/` (onboarding ja foi concluido) |
+
+---
+
+## Resumo de Redirecionamentos
+
+| Situacao | De | Para |
+|----------|-----|------|
+| Visitante tenta acessar rota protegida | `/feed`, `/onboarding` | `/` |
+| Autenticado sem perfil tenta acessar conteudo | `/`, `/feed`, qualquer rota que exige perfil | `/onboarding` |
+| Membro tenta acessar onboarding | `/onboarding` | `/` |
+
+## Componentes Reutilizaveis Sugeridos
+
+- **`AuthGuard`**: wrapper que verifica sessao e redireciona visitantes
+- **`OnboardingGuard`**: wrapper que verifica se perfil esta completo
+- **`ConditionalContent`**: componente que renderiza conteudo A ou B baseado no estado de auth
+- **`LoginCTA`**: call-to-action padrao para visitantes, com botao de login via Discord
+
+## Pontos em Aberto
+
+- **Sistema de admin**: como definir quem e admin? Opcoes: campo `isAdmin` na tabela `profile`, tabela separada de roles, ou lista de IDs no `.env`. Decisao a ser tomada antes de implementar Eventos e Feed (que tem funcionalidades restritas a admins).

--- a/src/docs/funcionalidades/01-onboarding-perfil.md
+++ b/src/docs/funcionalidades/01-onboarding-perfil.md
@@ -1,0 +1,247 @@
+# Onboarding e Perfil
+
+## Visao Geral
+
+Apos fazer login via Discord, o usuario precisa completar seu perfil na plataforma antes de acessar qualquer funcionalidade. O fluxo de onboarding coleta informacoes que compoem o perfil publico do usuario.
+
+O **username e herdado automaticamente do Discord** — nao ha campo para o usuario escolher um handle separado. Isso simplifica o fluxo e garante consistencia com a identidade do usuario na comunidade.
+
+## Comportamento por Estado de Autenticacao
+
+### Visitante em `/u/:username`
+
+Ve uma versao resumida e publica do perfil:
+- Nome de exibicao, avatar e bio
+- Lista de projetos do usuario (nome, categoria, status)
+- Banner com chamada para se cadastrar na comunidade
+
+Nao ve: contadores de seguidores, botao de seguir, posts recentes.
+
+### Usuario autenticado em `/u/:username` (perfil de outro usuario)
+
+Ve o perfil completo:
+- Nome de exibicao, avatar, bio, links (GitHub, Twitter, LinkedIn, site)
+- Areas de interesse
+- Projetos como owner e como contributor
+- Posts recentes de BIP
+- Contadores: seguidores, seguindo
+- Botao "Seguir" / "Deixar de seguir"
+
+### Usuario autenticado no proprio perfil `/u/:username`
+
+Tudo do perfil completo, mais:
+- Botao "Editar perfil" que leva para `/configuracoes`
+- Indicador visual de que e o proprio perfil
+
+---
+
+## Fluxo de Onboarding
+
+### Gatilho
+
+O onboarding e ativado quando:
+1. O usuario faz login via Discord (sessao criada)
+2. Nao existe registro na tabela `profile` para o `user.id`, **ou** o registro existe com `isOnboardingComplete = false`
+
+Nesse caso, qualquer tentativa de acessar rotas que exigem perfil completo resulta em redirecionamento para `/onboarding`.
+
+### Dados Pre-preenchidos do Discord
+
+O Better-Auth armazena na tabela `user`:
+- `name` — nome de exibicao do Discord (pre-preenche `displayName`)
+- `image` — URL do avatar do Discord (pre-preenche `avatarUrl`)
+
+O username do Discord precisa ser obtido via a API do Discord, usando o `accessToken` armazenado na tabela `account`. Essa chamada deve ser feita no momento do onboarding para popular o campo `username` automaticamente.
+
+### Etapas do Onboarding
+
+O formulario pode ser multi-step ou single-page. Recomendacao: **single-page com secoes visuais**, para simplificar a implementacao e permitir que o usuario preencha no seu ritmo.
+
+**Campos:**
+
+| Campo | Obrigatorio | Pre-preenchido | Descricao |
+|-------|------------|----------------|-----------|
+| `username` | Sim | Sim (do Discord) | Username do Discord, exibido como `@username`. Nao editavel |
+| `displayName` | Nao | Sim (do Discord) | Nome de exibicao. Se vazio, usa `user.name` |
+| `bio` | Nao | Nao | Bio curta (max 280 caracteres sugerido) |
+| `avatarUrl` | Nao | Sim (do Discord) | URL do avatar. Usa o do Discord por padrao |
+| `website` | Nao | Nao | URL do site pessoal |
+| `github` | Nao | Nao | Username do GitHub |
+| `twitter` | Nao | Nao | Handle do X/Twitter (sem @) |
+| `linkedin` | Nao | Nao | URL do perfil LinkedIn |
+| `interests` | Nao | Nao | Areas de interesse selecionaveis |
+
+### Areas de Interesse (Sugestoes)
+
+Lista pre-definida para selecao multipla:
+- Mobile (iOS/Android)
+- SaaS B2B
+- SaaS B2C
+- Micro-SaaS
+- AI / Machine Learning
+- Open Source
+- E-commerce
+- Fintech
+- EdTech
+- HealthTech
+- DevTools
+- Automacao
+- No-code / Low-code
+- Marketing Digital
+- Comunidades
+
+O campo `interests` e armazenado como JSON (`text` com `mode: "json"`) — um array de strings.
+
+### Finalizacao
+
+Ao submeter o formulario:
+1. Criar (ou atualizar) registro na tabela `profile`
+2. Marcar `isOnboardingComplete = true`
+3. Redirecionar para `/` (que agora mostra o Feed)
+
+### Perfil "Completo" vs "Incompleto"
+
+- **Incompleto**: `isOnboardingComplete = false` — usuario nao passou pelo onboarding ou nao finalizou
+- **Completo**: `isOnboardingComplete = true` — usuario passou pelo onboarding com sucesso
+
+O unico requisito para marcar como completo e ter passado pelo fluxo. Nao ha obrigatoriedade de preencher todos os campos opcionais.
+
+---
+
+## Schema: `profile.schema.ts`
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#profile-em-profileschemats).
+
+Resumo dos campos:
+
+```
+profile
+├── id (PK)
+├── userId (FK → user.id, UNIQUE)
+├── username (UNIQUE — do Discord)
+├── displayName
+├── bio
+├── avatarUrl
+├── website
+├── github
+├── twitter
+├── linkedin
+├── interests (JSON)
+├── isOnboardingComplete (boolean)
+├── createdAt
+└── updatedAt
+```
+
+---
+
+## Rotas
+
+### `/onboarding` — `src/routes/onboarding/page.tsx`
+
+Formulario de criacao de perfil.
+
+- **Visitante**: redireciona para `/`
+- **Autenticado sem perfil**: exibe o formulario
+- **Membro com perfil completo**: redireciona para `/`
+
+### `/u/:username` — `src/routes/u/$username/page.tsx`
+
+Pagina de perfil publico.
+
+- Carrega o perfil pelo `username` (parametro da URL)
+- Se nao encontrar, exibe pagina 404
+- Conteudo varia por estado de auth (ver secao acima)
+
+### `/configuracoes` — `src/routes/configuracoes/page.tsx`
+
+Pagina de edicao de perfil (apenas para o proprio usuario).
+
+- **Visitante**: redireciona para `/`
+- **Autenticado**: exibe formulario de edicao com todos os campos do perfil
+- Pre-preenche com os dados atuais do perfil
+- `username` continua nao editavel
+
+---
+
+## Server Functions
+
+### `getProfileByUsername(username: string)`
+Busca perfil pelo username. Usado para a pagina `/u/:username`.
+
+### `getProfileByUserId(userId: string)`
+Busca perfil pelo ID do usuario auth. Usado para verificar se onboarding foi concluido.
+
+### `createProfile(data: CreateProfileInput)`
+Cria registro de perfil no onboarding. Valida unicidade do username.
+
+### `updateProfile(userId: string, data: UpdateProfileInput)`
+Atualiza perfil existente. Nao permite alterar `username`.
+
+### `getDiscordUsername(userId: string)`
+Busca o username do Discord usando o `accessToken` da tabela `account`. Chamado durante o onboarding para popular o campo `username`.
+
+---
+
+## Validacao (Zod)
+
+```
+CreateProfileInput:
+  username: string — min 2, max 32, regex slug-safe (a-z, 0-9, _, .), readonly
+  displayName: string | null — max 100
+  bio: string | null — max 280
+  avatarUrl: string | null — URL valida
+  website: string | null — URL valida
+  github: string | null — max 39 (limite do GitHub)
+  twitter: string | null — max 15
+  linkedin: string | null — URL valida
+  interests: string[] | null — array de strings da lista pre-definida
+```
+
+---
+
+## Componentes
+
+### `ProfileCard`
+Card compacto de perfil (avatar, nome, username, bio curta). Usado em listagens.
+
+### `ProfilePage`
+Pagina completa de perfil com todas as secoes.
+
+### `ProfileForm`
+Formulario de edicao de perfil, reutilizado no onboarding e na pagina de configuracoes.
+
+### `InterestSelector`
+Seletor de areas de interesse com chips/tags selecionaveis.
+
+---
+
+## Pagina de Perfil — Secoes Exibidas
+
+1. **Header**: avatar, nome de exibicao, @username, bio
+2. **Links**: icones clicaveis para GitHub, Twitter, LinkedIn, site
+3. **Areas de interesse**: tags/chips
+4. **Contadores**: seguidores, seguindo (apenas para membros autenticados)
+5. **Projetos**: lista de projetos como owner e como contributor
+6. **Posts recentes**: ultimos posts de BIP do usuario (apenas para membros autenticados)
+
+---
+
+## Decisoes Tomadas
+
+### Obtencao do username do Discord
+
+**Abordagem escolhida: Chamar a API do Discord com o `accessToken` durante o onboarding.**
+
+A tabela `account` do Better-Auth ja armazena o `accessToken` do Discord. Durante o onboarding (que acontece logo apos o login), o token esta fresco. A server function `getDiscordUsername()` faz `GET https://discord.com/api/users/@me` com o token armazenado e retorna o campo `username`.
+
+**Fallback**: se o token expirou (usuario voltou dias depois sem completar o onboarding), a funcao retorna `null` e o formulario exibe aviso para re-logar.
+
+**Por que nao as outras opcoes:**
+- `mapProfileToUser`: campos extras retornados por essa funcao nao sao persistidos na tabela `user` (que nao devemos modificar), e combinar com `databaseHooks` adiciona complexidade desnecessaria ao auth config
+- Plugin `username` do Better-Auth: adiciona colunas a tabela `user` gerenciada pelo Better-Auth, conflitando com a regra de nao modificar `auth.schema.ts`
+
+---
+
+## Pontos em Aberto
+
+- **Avatar custom**: nesta versao, o avatar e sempre o do Discord. Permitir upload de avatar customizado e uma melhoria futura.

--- a/src/docs/funcionalidades/02-projetos.md
+++ b/src/docs/funcionalidades/02-projetos.md
@@ -1,0 +1,237 @@
+# Projetos
+
+## Visao Geral
+
+Usuarios publicam seus projetos na plataforma para dar visibilidade ao que estao construindo. Cada projeto tem um **owner** (dono) e pode ter **contributors** (colaboradores).
+
+Tipos de projeto suportados: **App**, **SaaS**, **Micro-SaaS**, **Startup** e **Outro**.
+
+Cada projeto passa por um ciclo de vida com status: **Ideia** → **Construindo** → **Lancado** → **Adquirido**.
+
+## Comportamento por Estado de Autenticacao
+
+### Visitante na listagem `/projects`
+
+- Ve a lista de projetos com informacoes basicas: nome, descricao curta, categoria, status
+- Nao pode interagir (sem botoes de seguir, recomendar, comentar)
+- Banner convidando a se cadastrar para criar e interagir com projetos
+
+### Visitante na pagina `/projects/:slug`
+
+- Ve descricao completa, equipe (membros com roles) e lista de recomendacoes
+- Nao pode recomendar, comentar, avaliar ou seguir
+- Banner de cadastro
+
+### Usuario autenticado (membro)
+
+- Na listagem: filtros por categoria e status, botao "Criar projeto" no topo
+- Na pagina: botoes de recomendar, comentar, avaliar e seguir o projeto
+
+### Owner do projeto
+
+Tudo do membro autenticado, mais:
+- Botao "Editar projeto"
+- Botao "Gerenciar colaboradores" (adicionar/remover contributors)
+- Botao "Excluir projeto"
+
+---
+
+## Schema: `projects.schema.ts`
+
+Este arquivo contem duas tabelas: `projects` e `project_members`.
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#projects-em-projectsschemats).
+
+### Tabela `projects`
+
+```
+projects
+├── id (PK)
+├── name (NOT NULL)
+├── slug (NOT NULL, UNIQUE)
+├── description
+├── url
+├── logoUrl
+├── category (NOT NULL, default "outro")
+│   valores: app | saas | micro_saas | startup | outro
+├── status (NOT NULL, default "ideia")
+│   valores: ideia | construindo | lancado | adquirido
+├── tags (JSON — array de strings)
+├── createdAt
+└── updatedAt
+```
+
+### Tabela `project_members`
+
+```
+project_members
+├── id (PK)
+├── projectId (FK → projects.id)
+├── userId (FK → user.id)
+├── role (NOT NULL, default "contributor")
+│   valores: owner | contributor
+└── joinedAt
+```
+
+---
+
+## Categorias
+
+| Valor | Exibicao | Descricao |
+|-------|---------|-----------|
+| `app` | App | Aplicativo mobile ou desktop |
+| `saas` | SaaS | Software as a Service |
+| `micro_saas` | Micro-SaaS | SaaS de nicho, operado por 1-2 pessoas |
+| `startup` | Startup | Empresa em estagio inicial |
+| `outro` | Outro | Nao se encaixa nas categorias acima |
+
+## Status (Ciclo de Vida)
+
+| Valor | Exibicao | Cor sugerida | Descricao |
+|-------|---------|-------------|-----------|
+| `ideia` | Ideia | Cinza | Apenas conceito, nao comecou a construir |
+| `construindo` | Construindo | Amarelo | Em desenvolvimento ativo |
+| `lancado` | Lancado | Verde | Produto disponivel para usuarios |
+| `adquirido` | Adquirido | Azul | Projeto vendido ou adquirido |
+
+---
+
+## Sistema de Roles
+
+### Owner
+
+- Criado automaticamente ao criar o projeto (o criador e sempre o owner)
+- **Unico** por projeto — nao pode haver dois owners
+- Pode: editar o projeto, excluir o projeto, adicionar/remover contributors
+- Nao pode: transferir ownership (funcionalidade futura, se necessario)
+
+### Contributor
+
+- Adicionado pelo owner
+- Pode haver **multiplos** contributors por projeto
+- Na pagina do projeto, contributors aparecem na secao de equipe
+- Nao pode editar o projeto ou gerenciar outros membros
+
+### Regras
+
+- Ao criar um projeto, um registro `project_members` com `role = "owner"` e criado automaticamente
+- O owner adiciona contributors buscando por username
+- O owner pode remover qualquer contributor
+- Um contributor pode se remover (sair do projeto)
+
+---
+
+## Rotas
+
+### `/projects` — `src/routes/projects/page.tsx`
+
+Listagem publica de projetos.
+
+- **Filtros**: por categoria, por status, busca por nome
+- **Ordenacao**: mais recentes primeiro (padrao), ou por nome
+- **Paginacao**: offset-based (projetos nao mudam de posicao com frequencia)
+- **Botao "Criar projeto"**: visivel apenas para membros autenticados
+
+### `/projects/novo` — `src/routes/projects/novo/page.tsx`
+
+Formulario de criacao de projeto. Rota protegida (requer autenticacao + perfil completo).
+
+### `/projects/:slug` — `src/routes/projects/$slug/page.tsx`
+
+Pagina individual do projeto.
+
+**Secoes:**
+1. **Header**: logo, nome, categoria badge, status badge
+2. **Descricao**: texto completo do projeto
+3. **Links**: URL do projeto, tags
+4. **Equipe**: lista de membros com roles (owner em destaque)
+5. **Recomendacoes**: lista de usuarios que recomendaram, com mensagem opcional
+6. **Comentarios**: comentarios em ordem cronologica, com avaliacoes (estrelas)
+
+### `/projects/:slug/editar` — `src/routes/projects/$slug/editar/page.tsx`
+
+Formulario de edicao. Acessivel apenas pelo owner.
+
+---
+
+## Server Functions
+
+### `createProject(data: CreateProjectInput)`
+Cria o projeto e o registro de `project_members` com `role = "owner"` em uma transacao.
+
+### `updateProject(projectId: string, userId: string, data: UpdateProjectInput)`
+Atualiza o projeto. Verifica se `userId` e owner antes de permitir.
+
+### `deleteProject(projectId: string, userId: string)`
+Exclui o projeto e todos os registros relacionados (cascade). Verifica ownership.
+
+### `getProjectBySlug(slug: string)`
+Busca projeto pelo slug, incluindo membros (com perfis) e contagem de recomendacoes.
+
+### `listProjects(filters: ProjectFilters)`
+Lista projetos com filtros e paginacao.
+
+### `addContributor(projectId: string, ownerId: string, contributorUserId: string)`
+Adiciona contributor. Verifica se `ownerId` e owner do projeto.
+
+### `removeContributor(projectId: string, requesterId: string, contributorUserId: string)`
+Remove contributor. Permite se `requesterId` e owner OU se `requesterId = contributorUserId` (auto-remocao).
+
+---
+
+## Geracao de Slug
+
+O slug e gerado automaticamente a partir do nome do projeto:
+
+1. Converter para minusculas
+2. Remover acentos (normalize + replace)
+3. Substituir espacos e caracteres especiais por `-`
+4. Remover hifens consecutivos
+5. Trimmar hifens no inicio e fim
+6. Se slug ja existir no banco, adicionar sufixo numerico (`-2`, `-3`, etc.)
+
+Exemplo: "Meu App Incrivel!" → `meu-app-incrivel`
+
+---
+
+## Validacao (Zod)
+
+```
+CreateProjectInput:
+  name: string — min 2, max 100
+  description: string | null — max 2000
+  url: string | null — URL valida
+  logoUrl: string | null — URL valida
+  category: enum — app | saas | micro_saas | startup | outro
+  status: enum — ideia | construindo | lancado | adquirido
+  tags: string[] | null — max 10 tags, cada uma max 30 chars
+```
+
+---
+
+## Componentes
+
+### `ProjectCard`
+Card de projeto para listagens. Exibe: logo, nome, descricao curta (truncada), categoria badge, status badge, contagem de recomendacoes.
+
+### `ProjectForm`
+Formulario reutilizado para criacao e edicao. Campos dinamicos baseados na categoria selecionada.
+
+### `ProjectStatusBadge`
+Badge colorido indicando o status do projeto.
+
+### `ProjectCategoryBadge`
+Badge indicando a categoria do projeto.
+
+### `TeamSection`
+Secao de equipe com lista de membros, destacando o owner. Botao "Adicionar colaborador" visivel apenas para o owner.
+
+### `AddContributorDialog`
+Dialog para buscar e adicionar contributors por username.
+
+---
+
+## Pontos em Aberto
+
+- **Upload de logo**: onde armazenar? Opcoes: Cloudflare R2 (integrado ao ecossistema), servico externo (Uploadthing, Cloudinary), ou apenas URL externa. Decisao afeta tambem o upload de avatar no perfil e banner de eventos.
+- **Tags**: lista pre-definida ou livre? Se livre, como evitar duplicatas e variações? Se pre-definida, qual a lista inicial?

--- a/src/docs/funcionalidades/03-eventos.md
+++ b/src/docs/funcionalidades/03-eventos.md
@@ -1,0 +1,193 @@
+# Eventos
+
+## Visao Geral
+
+O sistema de eventos e uma **vitrine simples** para divulgar eventos da comunidade Indie Hacking Brasil e de parceiros. Nesta versao inicial, **nao ha sistema de RSVP** — o objetivo e apenas informar sobre eventos e direcionar os interessados para a pagina oficial.
+
+A criacao e edicao de eventos e **restrita a admins**.
+
+## Comportamento por Estado de Autenticacao
+
+### Visitante
+
+Ve a listagem e as paginas de eventos normalmente. Eventos sao **conteudo 100% publico** — nao ha diferenca de conteudo entre visitante e membro autenticado nesta versao.
+
+### Membro autenticado
+
+Mesma experiencia do visitante. O RSVP e funcionalidade futura.
+
+### Admin
+
+Mesma experiencia + botoes "Criar evento", "Editar evento" e "Excluir evento".
+
+---
+
+## Schema: `events.schema.ts`
+
+Este arquivo contem duas tabelas: `events` e `event_members`.
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#events-em-eventsschemats).
+
+### Tabela `events`
+
+```
+events
+├── id (PK)
+├── name (NOT NULL)
+├── description
+├── date (NOT NULL — data e horario)
+├── format (NOT NULL)
+│   valores: presencial | digital
+├── address (condicional — obrigatorio se presencial)
+├── accessLink (condicional — obrigatorio se digital)
+├── eventLink (NOT NULL — link para pagina oficial)
+├── bannerUrl
+├── organizerName (NOT NULL)
+├── isPartner (boolean, default false)
+├── createdBy (FK → user.id — admin que cadastrou)
+├── createdAt
+└── updatedAt
+```
+
+### Tabela `event_members` (reservada para uso futuro)
+
+```
+event_members
+├── id (PK)
+├── eventId (FK → events.id)
+├── userId (FK → user.id)
+├── status (default "interessado")
+│   valores: interessado | nao_vou | confirmado
+└── createdAt
+```
+
+**Importante**: a tabela `event_members` e criada agora para evitar migrations complexas no futuro, mas **nenhuma funcionalidade de RSVP e exposta na interface**. Nao criar rotas, server functions ou componentes para RSVP nesta fase.
+
+---
+
+## Formatos de Evento
+
+| Valor | Descricao | Campos condicionais |
+|-------|-----------|-------------------|
+| `presencial` | Evento fisico | `address` obrigatorio |
+| `digital` | Evento online (Discord Stage, YouTube, Zoom, etc.) | `accessLink` obrigatorio |
+
+---
+
+## Organizador
+
+O campo `organizerName` identifica quem organiza o evento. O campo `isPartner` diferencia:
+
+| `isPartner` | Significado |
+|------------|------------|
+| `false` | Organizado pela propria comunidade Indie Hacking Brasil |
+| `true` | Organizado por um parceiro externo |
+
+Isso permite diferenciar visualmente eventos da comunidade de eventos de parceiros na listagem.
+
+---
+
+## Rotas
+
+### `/events` — `src/routes/events/page.tsx`
+
+Listagem de eventos, dividida em duas secoes:
+
+1. **Proximos eventos**: eventos com `date` no futuro, ordenados por data (mais proximo primeiro)
+2. **Eventos passados**: eventos com `date` no passado, ordenados por data (mais recente primeiro)
+
+- Admins veem botao "Criar evento" no topo
+- Nao ha paginacao nesta versao (volume baixo esperado)
+
+### `/events/:id` — `src/routes/events/$id/page.tsx`
+
+Pagina individual do evento.
+
+**Secoes:**
+1. **Banner** (se houver imagem)
+2. **Header**: nome do evento, data formatada, formato badge
+3. **Detalhes**: descricao, local ou link de acesso conforme formato
+4. **Organizador**: nome, badge de comunidade ou parceiro
+5. **CTA**: botao "Ver pagina oficial" linkando para `eventLink`
+6. **Acoes de admin**: botoes editar/excluir (visivel apenas para admins)
+
+### `/events/novo` — `src/routes/events/novo/page.tsx`
+
+Formulario de criacao. Restrito a admins.
+
+### `/events/:id/editar` — `src/routes/events/$id/editar/page.tsx`
+
+Formulario de edicao. Restrito a admins.
+
+---
+
+## Server Functions
+
+### `createEvent(adminUserId: string, data: CreateEventInput)`
+Cria evento. Verifica se o usuario e admin.
+
+### `updateEvent(eventId: string, adminUserId: string, data: UpdateEventInput)`
+Atualiza evento. Verifica se o usuario e admin.
+
+### `deleteEvent(eventId: string, adminUserId: string)`
+Exclui evento. Verifica se o usuario e admin.
+
+### `getEventById(eventId: string)`
+Busca evento por ID com todos os detalhes.
+
+### `listEvents()`
+Lista todos os eventos, separados em proximos e passados.
+
+---
+
+## Validacao (Zod)
+
+```
+CreateEventInput:
+  name: string — min 2, max 200
+  description: string | null — max 1000
+  date: Date — deve ser no futuro (para criacao)
+  format: enum — presencial | digital
+  address: string | null — obrigatorio se format = presencial
+  accessLink: string | null — URL valida, obrigatorio se format = digital
+  eventLink: string — URL valida, obrigatorio
+  bannerUrl: string | null — URL valida
+  organizerName: string — min 2, max 100
+  isPartner: boolean — default false
+```
+
+Validacao condicional: `address` e obrigatorio quando `format = "presencial"`, `accessLink` e obrigatorio quando `format = "digital"`.
+
+---
+
+## Componentes
+
+### `EventCard`
+Card de evento para listagem. Exibe: nome, data formatada, formato badge, organizador, badge de comunidade/parceiro.
+
+### `EventForm`
+Formulario de criacao/edicao. Campos condicionais baseados no formato selecionado (presencial mostra campo de endereco, digital mostra campo de link de acesso).
+
+### `EventFormatBadge`
+Badge visual indicando se o evento e presencial ou digital.
+
+### `EventPartnerBadge`
+Badge indicando se e evento da comunidade ou de parceiro.
+
+---
+
+## Formatacao de Data
+
+Datas devem ser exibidas em formato brasileiro:
+- Listagem: "15 de mar. de 2026, 19:00"
+- Pagina do evento: "Sabado, 15 de marco de 2026 as 19:00"
+
+Usar `Intl.DateTimeFormat("pt-BR", ...)` para formatacao consistente.
+
+---
+
+## Pontos em Aberto
+
+- **Sistema de admin**: definicao de como verificar se um usuario e admin (mesmo ponto em aberto do [`conteudo-condicional.md`](../conteudo-condicional.md#pontos-em-aberto))
+- **Upload de banner**: mesma decisao de storage do upload de logo de projetos
+- **Eventos recorrentes**: nao suportado nesta versao. Se necessario, cada ocorrencia seria um evento separado

--- a/src/docs/funcionalidades/04-feed.md
+++ b/src/docs/funcionalidades/04-feed.md
@@ -1,0 +1,186 @@
+# Feed / Build In Public
+
+## Visao Geral
+
+O Feed e o coracao da plataforma — um espaco onde membros compartilham atualizacoes sobre seus projetos (Build In Public) e admins publicam comunicados da comunidade. A exibicao e **cronologica reversa** (mais recente primeiro), sem algoritmo.
+
+## Comportamento por Estado de Autenticacao
+
+### Visitante na Home `/`
+
+Nao ve o Feed. Em vez disso, ve a **Landing Page** com:
+- Apresentacao da comunidade Indie Hacking Brasil
+- Banner de chamada para entrar no Discord
+- Projetos em destaque
+- Proximos eventos
+- Numeros da comunidade (membros, projetos, etc.)
+
+### Membro autenticado na Home `/`
+
+O Feed **substitui a Landing Page completamente**. A mesma rota `/` exibe conteudo diferente conforme o estado de auth.
+
+### Rota `/feed`
+
+URL dedicada para o Feed. Acessivel apenas para membros autenticados. Visitantes sao redirecionados para `/`.
+
+---
+
+## Schema: `posts.schema.ts`
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#posts-em-postsschemats).
+
+```
+posts
+├── id (PK)
+├── authorId (FK → user.id)
+├── type (NOT NULL)
+│   valores: announcement | build_in_public
+├── content (NOT NULL — Markdown)
+├── imageUrl
+├── projectId (FK → projects.id, opcional)
+└── createdAt
+```
+
+**Nota**: posts sao **imutaveis** apos publicacao — nao tem campo `updatedAt`. Se o autor quiser corrigir algo, exclui e recria o post.
+
+---
+
+## Tipos de Post
+
+### `announcement` — Comunicado
+
+- Criado **apenas por admins**
+- Aparece com **destaque visual** diferenciado no feed (borda, icone ou cor de fundo distintos)
+- Usado para novidades da comunidade, avisos, mudancas de regra, etc.
+- Nao e vinculado a um projeto
+
+### `build_in_public` — Build In Public (BIP)
+
+- Criado por **qualquer membro com perfil completo**
+- Pode (opcionalmente) ser vinculado a um projeto via `projectId`
+- Quando vinculado, exibe informacoes resumidas do projeto junto ao post (nome, logo, status)
+- Conteudo tipico: atualizacoes de desenvolvimento, marcos alcancados, metricas, aprendizados, perguntas
+
+---
+
+## Comportamento do Feed
+
+### Exibicao
+
+- **Ordem**: cronologica reversa — mais recente primeiro
+- **Feed unificado**: announcements e BIP aparecem juntos no mesmo fluxo
+- **Indicacao visual**: cada post tem badge ou icone indicando seu tipo
+- Announcements tem destaque visual (ex.: fundo sutil diferente, icone de megafone)
+
+### Filtros
+
+Filtro opcional no topo do feed:
+- **Todos** (padrao) — announcements + BIP misturados
+- **Build In Public** — somente posts BIP
+- **Comunicados** — somente announcements
+
+### Paginacao
+
+**Cursor-based** (recomendada para feeds cronologicos):
+- O cursor e o `createdAt` do ultimo post carregado
+- Cada pagina carrega N posts com `createdAt < cursor`
+- Evita problemas de offset com posts novos sendo criados enquanto o usuario navega
+- Implementacao: `WHERE created_at < ? ORDER BY created_at DESC LIMIT ?`
+
+### Formulario de Novo Post
+
+No topo do feed, formulario inline para criar um novo post:
+- Campo de texto com suporte a Markdown
+- Seletor de projeto (opcional) — dropdown com projetos do usuario
+- Upload de imagem (opcional)
+- Botao "Publicar"
+
+Admins veem um toggle adicional para marcar o post como `announcement`.
+
+---
+
+## Suporte a Markdown
+
+O campo `content` aceita Markdown. Na exibicao:
+- Renderizar Markdown para HTML
+- Sanitizar o HTML para evitar XSS (usar lib como `rehype-sanitize`)
+- Suportar: headings, bold, italic, links, listas, code blocks, imagens inline
+
+No formulario de criacao, oferecer preview do Markdown antes de publicar.
+
+---
+
+## Rotas
+
+### `/` — `src/routes/page.tsx`
+
+Rota da Home. Renderiza condicionalmente:
+- Visitante: Landing Page
+- Membro: Feed (mesmo componente que `/feed`)
+
+### `/feed` — `src/routes/feed/page.tsx`
+
+Rota dedicada do Feed. Protegida (requer auth + perfil completo).
+
+---
+
+## Server Functions
+
+### `createPost(data: CreatePostInput)`
+Cria post. Se `type = "announcement"`, verifica se o usuario e admin.
+
+### `deletePost(postId: string, userId: string)`
+Exclui post. Permite se `userId` e o autor do post ou um admin.
+
+### `listFeed(cursor?: number, limit?: number, type?: string)`
+Lista posts com paginacao cursor-based. Filtra por tipo se especificado.
+
+Retorna para cada post:
+- Dados do post
+- Dados do autor (nome, username, avatar — via join com profile)
+- Dados do projeto vinculado, se houver (nome, logo, slug — via join com projects)
+
+### `getUserPosts(userId: string, cursor?: number, limit?: number)`
+Lista posts de um usuario especifico. Usado na pagina de perfil.
+
+---
+
+## Validacao (Zod)
+
+```
+CreatePostInput:
+  type: enum — announcement | build_in_public
+  content: string — min 1, max 5000
+  imageUrl: string | null — URL valida
+  projectId: string | null — UUID valido, deve ser projeto existente do usuario
+```
+
+---
+
+## Componentes
+
+### `FeedList`
+Lista de posts com infinite scroll (carrega mais ao chegar no final).
+
+### `PostCard`
+Card de post individual. Exibe: avatar do autor, nome, username, data relativa ("ha 2 horas"), tipo badge, conteudo renderizado (Markdown → HTML), imagem (se houver), projeto vinculado (se houver).
+
+### `CreatePostForm`
+Formulario inline no topo do feed. Textarea com preview Markdown, seletor de projeto, upload de imagem.
+
+### `PostTypeFilter`
+Filtros no topo do feed: Todos / Build In Public / Comunicados.
+
+### `LinkedProjectPreview`
+Preview compacto do projeto vinculado ao post (logo, nome, status badge). Clicavel, leva para a pagina do projeto.
+
+### `LandingPage`
+Componente da Landing Page exibida para visitantes na Home.
+
+---
+
+## Pontos em Aberto
+
+- **Reacoes em posts**: nesta especificacao, posts nao tem reacoes (likes, etc.). Seria uma evolucao natural para a Fase 5 (Social), mas nao esta no escopo definido. Avaliar se faz sentido incluir.
+- **Edicao de posts**: a decisao atual e que posts sao imutaveis. Se isso gerar fricacao com usuarios, considerar adicionar `updatedAt` e funcionalidade de edicao.
+- **Limite de imagem**: definir tamanho maximo e formato aceito para `imageUrl`. Se usando URL externa, validar que e uma URL de imagem valida.

--- a/src/docs/funcionalidades/05-social.md
+++ b/src/docs/funcionalidades/05-social.md
@@ -1,0 +1,265 @@
+# Funcionalidades Sociais
+
+## Visao Geral
+
+A plataforma oferece um conjunto de interacoes sociais entre usuarios e projetos:
+
+1. **Seguir usuarios** — acompanhar a atividade de outros membros
+2. **Seguir projetos** — acompanhar atualizacoes de projetos
+3. **Recomendar projetos** — endosso publico de um projeto
+4. **Comentar e avaliar projetos** — feedback em projetos de outros membros
+
+Todas as interacoes sociais requerem **perfil completo** (onboarding concluido).
+
+---
+
+## 1. Follows (Seguir)
+
+### Schema: `follows.schema.ts`
+
+Tabela polimorfica que cobre seguir usuarios e projetos no mesmo modelo. Em arquivo proprio porque cruza dominios.
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#follows-em-followsschemats).
+
+```
+follows
+├── id (PK)
+├── followerId (FK → user.id — quem segue)
+├── targetType (user | project)
+├── targetId (ID do usuario ou projeto seguido)
+└── createdAt
+```
+
+Indice unico em (`followerId`, `targetType`, `targetId`) — evita follows duplicados.
+
+### Comportamento
+
+- **Seguir e silencioso** — nao gera notificacao nesta versao
+- Um usuario **nao pode seguir a si mesmo**
+- O botao "Seguir"/"Deixar de seguir" aparece:
+  - Na pagina de perfil de outro usuario
+  - Na pagina de um projeto
+  - Nos cards de projeto e perfil em listagens (opcional)
+
+### Contadores
+
+- **Perfil do usuario**: exibe "X seguidores" e "Seguindo Y"
+- **Pagina do projeto**: exibe "X seguidores"
+- Contadores sao calculados via `COUNT` na tabela `follows` com o filtro de `targetType` e `targetId`
+
+### Server Functions
+
+#### `followTarget(followerId: string, targetType: string, targetId: string)`
+Cria registro de follow. Valida que o alvo existe e que nao e auto-follow.
+
+#### `unfollowTarget(followerId: string, targetType: string, targetId: string)`
+Remove registro de follow.
+
+#### `isFollowing(followerId: string, targetType: string, targetId: string)`
+Verifica se o usuario ja segue o alvo. Usado para renderizar o estado do botao.
+
+#### `getFollowerCount(targetType: string, targetId: string)`
+Conta seguidores de um alvo.
+
+#### `getFollowingCount(userId: string)`
+Conta quantos usuarios/projetos o usuario segue.
+
+#### `getFollowers(targetType: string, targetId: string, cursor?: number)`
+Lista seguidores de um alvo com paginacao.
+
+#### `getFollowing(userId: string, targetType?: string, cursor?: number)`
+Lista quem/o que o usuario segue, com filtro opcional por tipo.
+
+### Componentes
+
+#### `FollowButton`
+Botao toggle: "Seguir" (outline) / "Seguindo" (filled). Ao hover no estado "Seguindo", muda para "Deixar de seguir" (vermelho).
+
+#### `FollowerCount`
+Texto clicavel "X seguidores" que abre lista de seguidores.
+
+---
+
+## 2. Recomendacoes
+
+### Schema: `recommendations.schema.ts`
+
+Endosso publico de um usuario para um projeto. Diferente de um "like" — e uma recomendacao com peso social, pois mostra publicamente quem recomendou.
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#recommendations-em-recommendationsschemats).
+
+```
+recommendations
+├── id (PK)
+├── userId (FK → user.id — quem recomenda)
+├── projectId (FK → projects.id)
+├── message (texto curto opcional)
+└── createdAt
+```
+
+Indice unico em (`userId`, `projectId`) — um usuario so pode recomendar o mesmo projeto uma vez.
+
+### Regras de Negocio
+
+- Um usuario so pode recomendar o mesmo projeto **uma vez**
+- O **owner do projeto nao pode recomendar o proprio projeto** (validacao na aplicacao)
+- Contributors **podem** recomendar o projeto em que participam
+- A recomendacao e **publica** — aparece na pagina do projeto com nome e avatar de quem recomendou
+- A mensagem e opcional — o usuario pode recomendar sem explicar o motivo
+
+### Exibicao na Pagina do Projeto
+
+Secao "Recomendacoes" mostrando:
+- Contagem total ("12 recomendacoes")
+- Lista de quem recomendou: avatar, nome, e mensagem (se houver)
+- Botao "Recomendar" para quem ainda nao recomendou
+- Texto "Voce ja recomendou este projeto" para quem ja recomendou (com opcao de remover)
+
+### Server Functions
+
+#### `recommendProject(userId: string, projectId: string, message?: string)`
+Cria recomendacao. Valida: usuario nao e owner, nao recomendou antes.
+
+#### `removeRecommendation(userId: string, projectId: string)`
+Remove a propria recomendacao.
+
+#### `getProjectRecommendations(projectId: string)`
+Lista todas as recomendacoes de um projeto com dados dos usuarios.
+
+#### `hasRecommended(userId: string, projectId: string)`
+Verifica se o usuario ja recomendou o projeto.
+
+#### `getRecommendationCount(projectId: string)`
+Conta recomendacoes de um projeto.
+
+### Componentes
+
+#### `RecommendButton`
+Botao para recomendar um projeto. Pode abrir um dialog para adicionar mensagem opcional.
+
+#### `RecommendationList`
+Lista de recomendacoes na pagina do projeto. Cada item: avatar, nome (link para perfil), mensagem.
+
+#### `RecommendDialog`
+Dialog com textarea para mensagem opcional e botao de confirmar.
+
+---
+
+## 3. Comentarios e Avaliacoes
+
+### Schema: `comments.schema.ts`
+
+Comentarios e avaliacoes em projetos. Cada comentario pode ter uma nota (rating) opcional de 1 a 5.
+
+Ver definicao completa em [`schema-banco-de-dados.md`](../schema-banco-de-dados.md#comments-em-commentsschemats).
+
+```
+comments
+├── id (PK)
+├── authorId (FK → user.id)
+├── projectId (FK → projects.id)
+├── content (NOT NULL — Markdown)
+├── rating (1-5, opcional)
+├── createdAt
+└── updatedAt
+```
+
+### Regras para Rating
+
+A regra de rating merece atencao especial:
+
+- Um usuario pode deixar **multiplos comentarios** no mesmo projeto (feedback continuo)
+- Um usuario pode deixar **apenas uma avaliacao (rating)** por projeto
+- Se o usuario ja avaliou e submeter novo comentario com rating, o rating anterior e atualizado
+- Comentarios sem rating sao ilimitados
+
+**Implementacao sugerida:**
+1. Ao submeter comentario com rating, verificar se ja existe um rating do usuario para o projeto
+2. Se sim: atualizar o rating no comentario existente e criar o novo comentario sem rating
+3. Se nao: criar o comentario com o rating
+
+### Media de Avaliacoes
+
+A pagina do projeto exibe a **media das avaliacoes** e a quantidade de avaliacoes:
+- "4.2 / 5 (23 avaliacoes)"
+- Calculada via `AVG(rating)` e `COUNT(rating)` nos comentarios com `rating IS NOT NULL`
+
+### Exibicao na Pagina do Projeto
+
+Secao "Comentarios e Avaliacoes":
+1. **Resumo de avaliacoes**: media, quantidade, distribuicao por estrela (grafico de barras horizontal simples)
+2. **Formulario de novo comentario**: textarea + seletor de estrelas (opcional)
+3. **Lista de comentarios**: ordem cronologica (mais recente primeiro)
+   - Cada comentario: avatar, nome, data, estrelas (se houver), conteudo
+
+### Permissoes
+
+- **Criar comentario**: qualquer membro com perfil completo
+- **Editar comentario**: apenas o autor
+- **Excluir comentario**: autor ou admin
+- **Owner do projeto**: pode comentar no proprio projeto (ex.: responder perguntas), mas nao pode se auto-avaliar (rating bloqueado no proprio projeto)
+
+### Server Functions
+
+#### `createComment(data: CreateCommentInput)`
+Cria comentario. Se incluir rating, verifica a regra de rating unico.
+
+#### `updateComment(commentId: string, authorId: string, data: UpdateCommentInput)`
+Atualiza comentario. Apenas o autor pode editar.
+
+#### `deleteComment(commentId: string, requesterId: string)`
+Exclui comentario. Permite se for o autor ou admin.
+
+#### `getProjectComments(projectId: string, cursor?: number)`
+Lista comentarios do projeto com paginacao cursor-based.
+
+#### `getProjectRatingSummary(projectId: string)`
+Retorna media, contagem total e distribuicao por estrela.
+
+### Validacao (Zod)
+
+```
+CreateCommentInput:
+  projectId: string — UUID valido
+  content: string — min 1, max 2000
+  rating: number | null — inteiro de 1 a 5
+```
+
+### Componentes
+
+#### `CommentList`
+Lista de comentarios com paginacao.
+
+#### `CommentCard`
+Card de comentario individual: avatar, nome, data, estrelas (se houver), conteudo Markdown renderizado.
+
+#### `CommentForm`
+Formulario: textarea + seletor de estrelas opcional + botao "Comentar".
+
+#### `RatingSummary`
+Exibicao da media de avaliacoes com estrelas visuais e barra de distribuicao.
+
+#### `StarRating`
+Componente de selecao de estrelas (1-5), reutilizado no formulario e na exibicao.
+
+---
+
+## Requisitos Transversais
+
+### Perfil Completo Obrigatorio
+
+Todas as interacoes sociais (seguir, recomendar, comentar) requerem `profile.isOnboardingComplete = true`. Se o usuario tentar interagir sem perfil completo, deve ser redirecionado para o onboarding.
+
+### Performance
+
+- Contadores (seguidores, recomendacoes, media de avaliacoes) podem ser cacheados se o volume crescer
+- Para o escopo inicial, calcular em tempo real via queries agregadas e suficiente
+- Queries de feed social (posts de quem o usuario segue) sao complexas — considerar desnormalizar se necessario no futuro
+
+---
+
+## Pontos em Aberto
+
+- **Notificacoes**: nao ha sistema de notificacoes nesta versao. Follows, recomendacoes e comentarios sao "silenciosos". Notificacoes sao planejadas para uma fase futura.
+- **Moderacao de comentarios**: nao ha sistema de report/denuncia ou moderacao automatica. Se necessario, adicionar campo `isHidden` e fluxo de report.
+- **Follows polimorficos vs tabelas separadas**: a abordagem polimorfica (campo `targetType`) e mais simples, mas impede FKs no banco. Se a integridade referencial for preocupacao, considerar tabelas separadas `user_follows` e `project_follows`. Para o escopo atual, a abordagem polimorfica e adequada.

--- a/src/docs/roadmap.md
+++ b/src/docs/roadmap.md
@@ -1,0 +1,208 @@
+# Roadmap de Desenvolvimento
+
+## Fase 0 — Fundacao (Concluida)
+
+Infraestrutura base ja implementada:
+
+- [x] TanStack Start (React 19 + Vite) configurado
+- [x] Deploy em Cloudflare Workers funcional
+- [x] Autenticacao com Discord via Better-Auth
+- [x] Banco de dados D1 com tabelas de auth (user, session, account, verification)
+- [x] Drizzle ORM configurado com migrations
+- [x] 30+ componentes shadcn/ui instalados
+- [x] Tema claro/escuro (next-themes)
+- [x] Biome para linting/formatacao
+- [x] Estrutura de pastas definida
+
+---
+
+## Fase 1 — Onboarding e Perfil
+
+> **Foco atual** — primeira funcionalidade a ser implementada.
+
+**Documentacao**: [`funcionalidades/01-onboarding-perfil.md`](./funcionalidades/01-onboarding-perfil.md)
+
+### Entregas
+
+- [ ] Criar `profile.schema.ts` com tabela `profile`
+- [ ] Atualizar `index.ts` do schema para exportar profile
+- [ ] Gerar e aplicar migration
+- [ ] Resolver obtencao do username do Discord (via API ou `mapProfileToUser`)
+- [ ] Server functions: `createProfile`, `updateProfile`, `getProfileByUsername`, `getProfileByUserId`
+- [ ] Validacao Zod para inputs de perfil
+- [ ] Rota `/onboarding` com formulario de criacao de perfil
+- [ ] Guard de onboarding (redirecionar usuario sem perfil)
+- [ ] Rota `/u/:username` com pagina de perfil publico
+- [ ] Rota `/configuracoes` com formulario de edicao
+- [ ] Componentes: ProfileCard, ProfileForm, InterestSelector
+- [ ] Logica de conteudo condicional na Home (Landing Page vs redirect para onboarding)
+
+### Dependencias
+
+- Nenhuma (alem da Fase 0 ja concluida)
+
+### Pre-requisito para proximas fases
+
+Todas as fases seguintes dependem do perfil estar implementado, pois `user.id` e referenciado como FK em praticamente todas as tabelas.
+
+---
+
+## Fase 2 — Projetos
+
+**Documentacao**: [`funcionalidades/02-projetos.md`](./funcionalidades/02-projetos.md)
+
+### Entregas
+
+- [ ] Criar `projects.schema.ts` com tabelas `projects` e `project_members`
+- [ ] Gerar e aplicar migration
+- [ ] Server functions: CRUD de projetos, gerenciamento de contributors
+- [ ] Validacao Zod para inputs de projeto
+- [ ] Geracao automatica de slug
+- [ ] Rota `/projects` com listagem e filtros
+- [ ] Rota `/projects/novo` com formulario de criacao
+- [ ] Rota `/projects/:slug` com pagina individual
+- [ ] Rota `/projects/:slug/editar` com formulario de edicao (owner only)
+- [ ] Componentes: ProjectCard, ProjectForm, ProjectStatusBadge, TeamSection, AddContributorDialog
+- [ ] Sistema de roles: owner automatico na criacao, adicao/remocao de contributors
+
+### Dependencias
+
+- Fase 1 (Perfil) — precisa de `user.id` para FK em `project_members`
+
+---
+
+## Fase 3 — Eventos
+
+**Documentacao**: [`funcionalidades/03-eventos.md`](./funcionalidades/03-eventos.md)
+
+### Entregas
+
+- [ ] Criar `events.schema.ts` com tabelas `events` e `event_members`
+- [ ] Gerar e aplicar migration
+- [ ] Definir sistema de admin (como marcar usuarios como admin)
+- [ ] Server functions: CRUD de eventos (admin-only)
+- [ ] Validacao Zod com campos condicionais (presencial vs digital)
+- [ ] Rota `/events` com listagem (proximos + passados)
+- [ ] Rota `/events/:id` com pagina individual
+- [ ] Rota `/events/novo` e `/events/:id/editar` (admin-only)
+- [ ] Componentes: EventCard, EventForm, EventFormatBadge
+- [ ] Formatacao de datas em pt-BR
+
+### Dependencias
+
+- Fase 1 (Perfil) — precisa de `user.id` para `createdBy`
+- Sistema de admin definido
+
+### Nota
+
+A tabela `event_members` e criada nesta fase mas nao e exposta na interface. Funcionalidade de RSVP e futura.
+
+---
+
+## Fase 4 — Feed / Build In Public
+
+**Documentacao**: [`funcionalidades/04-feed.md`](./funcionalidades/04-feed.md)
+
+### Entregas
+
+- [ ] Criar `posts.schema.ts` com tabela `posts`
+- [ ] Gerar e aplicar migration
+- [ ] Server functions: criar post, listar feed, excluir post
+- [ ] Paginacao cursor-based
+- [ ] Renderizacao de Markdown para HTML (com sanitizacao)
+- [ ] Conteudo condicional na Home: Landing Page (visitante) vs Feed (membro)
+- [ ] Rota `/feed` dedicada (protegida)
+- [ ] Componentes: FeedList, PostCard, CreatePostForm, PostTypeFilter, LandingPage
+- [ ] Filtros por tipo (todos / BIP / comunicados)
+- [ ] Destaque visual para announcements
+- [ ] Vinculo de post com projeto (opcional)
+
+### Dependencias
+
+- Fase 1 (Perfil) — precisa de `user.id` para `authorId`
+- Fase 2 (Projetos) — para vinculo de post com projeto via `projectId`
+- Sistema de admin — para posts do tipo `announcement`
+
+---
+
+## Fase 5 — Funcionalidades Sociais
+
+**Documentacao**: [`funcionalidades/05-social.md`](./funcionalidades/05-social.md)
+
+### Entregas
+
+- [ ] Criar `follows.schema.ts` com tabela `follows`
+- [ ] Criar `recommendations.schema.ts` com tabela `recommendations`
+- [ ] Criar `comments.schema.ts` com tabela `comments`
+- [ ] Gerar e aplicar migrations
+- [ ] Server functions: follow/unfollow, recomendar/remover recomendacao, CRUD de comentarios
+- [ ] Logica de rating unico por usuario/projeto
+- [ ] Calculo de media de avaliacoes
+- [ ] Botao "Seguir" em perfis e projetos
+- [ ] Contadores de seguidores em perfis e projetos
+- [ ] Secao "Recomendacoes" na pagina de projeto
+- [ ] Secao "Comentarios e Avaliacoes" na pagina de projeto
+- [ ] Componentes: FollowButton, RecommendButton, RecommendationList, CommentList, CommentForm, StarRating, RatingSummary
+
+### Dependencias
+
+- Fase 1 (Perfil) — precisa de `user.id` para todas as tabelas
+- Fase 2 (Projetos) — precisa de `projects.id` para recomendacoes e comentarios
+
+---
+
+## Futuro (Sem Fase Definida)
+
+Funcionalidades planejadas para alem das 5 fases iniciais, sem ordem de prioridade definida:
+
+### RSVP para Eventos
+- Ativar funcionalidade da tabela `event_members` (ja criada na Fase 3)
+- Status: interessado, nao vou, confirmado
+- Limite de vagas com lista de espera
+- Contador de confirmados na pagina do evento
+
+### Sistema de Notificacoes
+- Notificacoes in-app para: novo seguidor, recomendacao recebida, comentario no projeto, novo post de quem segue
+- Centro de notificacoes (`/notificacoes`)
+- Badge de contagem no header
+- Opcoes de preferencia de notificacao
+
+### Integracao com Bot do Discord
+- Notificar no Discord quando: novo projeto publicado, novo evento criado, marcos de BIP
+- Sincronizar roles do Discord com permissoes na plataforma (ex.: role de admin)
+- Comando de bot para consultar perfil/projeto diretamente no Discord
+
+### Busca Global
+- Busca unificada por: usuarios, projetos, posts, eventos
+- Implementacao com SQLite FTS5 (Full-Text Search)
+- Barra de busca no header com resultados categorized
+
+### Email Transacional
+- Infraestrutura ja parcialmente preparada (Resend API key no `.env`)
+- Emails para: boas-vindas, resumo semanal, notificacoes importantes
+- Templates em pt-BR
+
+### Feed Personalizado
+- Opcao de ver apenas posts de usuarios/projetos que segue
+- Feed "Descubra" com projetos novos e populares
+
+### Analytics para Projetos
+- Dashboard do owner com metricas: visitas ao perfil, recomendacoes ao longo do tempo, seguidores
+- Metricas opcionais: MRR, usuarios ativos (informados manualmente pelo owner)
+
+---
+
+## Tarefas Tecnicas Transversais
+
+Tarefas que devem ser feitas em paralelo ou entre as fases:
+
+- [ ] **Atualizar `site.ts`**: mudar `name` de "Rychillie" para "Indie Hacking Brasil"
+- [ ] **Meta tags**: adicionar Open Graph e Twitter Cards no `__root.tsx` para SEO
+- [ ] **Error boundaries**: implementar paginas de erro 404 e 500
+- [ ] **Loading states**: skeleton screens consistentes para todas as paginas
+- [ ] **Responsividade**: garantir que todas as paginas funcionam bem em mobile
+- [ ] **Acessibilidade**: labels, focus management, contraste adequado
+- [ ] **Storage de imagens**: decidir solucao para upload (R2, Uploadthing, ou URL externa)
+- [ ] **Sistema de admin**: definir como identificar admins (campo no profile, env var, ou tabela separada)
+- [ ] **Geracao de IDs**: definir estrategia (`crypto.randomUUID()` vs `nanoid`)
+- [ ] **Rate limiting**: proteger endpoints de criacao contra abuso

--- a/src/docs/schema-banco-de-dados.md
+++ b/src/docs/schema-banco-de-dados.md
@@ -1,0 +1,453 @@
+# Schema do Banco de Dados
+
+## Visao Geral
+
+O banco de dados usa **Cloudflare D1 (SQLite)** com **Drizzle ORM**. Os schemas sao organizados por dominio, cada um em seu proprio arquivo dentro de `src/lib/db/schema/`.
+
+## Convencoes
+
+Todas as tabelas seguem as convencoes estabelecidas pelo `auth.schema.ts`:
+
+- **IDs**: `text("id").primaryKey()` — strings geradas pela aplicacao (UUIDs)
+- **Timestamps**: `integer("col", { mode: "timestamp_ms" })` com `default(sql\`(unixepoch() * 1000)\`)`
+- **Booleans**: `integer("col", { mode: "boolean" })`
+- **Strings**: `text("col")` — sem limite de tamanho (SQLite nao enforça)
+- **Enum-like**: `text("col")` com validacao Zod na camada de aplicacao
+- **Foreign keys**: `.references(() => tabela.id, { onDelete: "cascade" })`
+- **Indices**: terceiro argumento do `sqliteTable()`, retornando array
+- **Naming**: `snake_case` no banco, `camelCase` no TypeScript
+- **Relations**: definidas com `relations()` do `drizzle-orm` para o query builder
+
+## Arquivos de Schema
+
+| Arquivo | Responsabilidade | Dependencias |
+|---------|-----------------|-------------|
+| `auth.schema.ts` | Usuarios e sessoes do Better-Auth | Nenhuma (existente, NAO modificar) |
+| `profile.schema.ts` | Perfil publico do usuario | `auth.schema.ts` (user) |
+| `projects.schema.ts` | Projetos + membros e roles | `auth.schema.ts` (user) |
+| `events.schema.ts` | Eventos + membros/RSVP (futuro) | `auth.schema.ts` (user) |
+| `posts.schema.ts` | Posts do feed (BIP e comunicados) | `auth.schema.ts` (user), `projects.schema.ts` |
+| `follows.schema.ts` | Seguir usuarios e projetos | `auth.schema.ts` (user), `projects.schema.ts` |
+| `recommendations.schema.ts` | Recomendacoes de projetos | `auth.schema.ts` (user), `projects.schema.ts` |
+| `comments.schema.ts` | Comentarios e avaliacoes | `auth.schema.ts` (user), `projects.schema.ts` |
+
+### Ordem de Criacao (por dependencia)
+
+1. `auth.schema.ts` — ja existe
+2. `profile.schema.ts` — depende de `user`
+3. `projects.schema.ts` — depende de `user`
+4. `events.schema.ts` — depende de `user`
+5. `posts.schema.ts` — depende de `user` e `projects`
+6. `follows.schema.ts` — depende de `user` e `projects`
+7. `recommendations.schema.ts` — depende de `user` e `projects`
+8. `comments.schema.ts` — depende de `user` e `projects`
+
+Apos criar cada schema, atualizar `src/lib/db/schema/index.ts` para re-exportar:
+
+```typescript
+export * from "./auth.schema";
+export * from "./profile.schema";
+export * from "./projects.schema";
+// ... etc
+```
+
+---
+
+## Tabelas Existentes (Auth)
+
+> **NAO MODIFICAR** — estas tabelas sao gerenciadas pelo Better-Auth.
+
+### `user`
+
+| Campo | Tipo Drizzle | Restricoes |
+|-------|-------------|-----------|
+| `id` | `text("id")` | PK |
+| `name` | `text("name")` | NOT NULL |
+| `email` | `text("email")` | NOT NULL, UNIQUE |
+| `emailVerified` | `integer("email_verified", { mode: "boolean" })` | NOT NULL, default `false` |
+| `image` | `text("image")` | — |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update |
+
+Indices: `user_email_unique` em `email`.
+
+### `session`
+
+| Campo | Tipo Drizzle | Restricoes |
+|-------|-------------|-----------|
+| `id` | `text("id")` | PK |
+| `expiresAt` | `integer("expires_at", { mode: "timestamp_ms" })` | NOT NULL |
+| `token` | `text("token")` | NOT NULL, UNIQUE |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update |
+| `ipAddress` | `text("ip_address")` | — |
+| `userAgent` | `text("user_agent")` | — |
+| `userId` | `text("user_id")` | NOT NULL, FK → `user.id` CASCADE |
+
+Indices: `session_userId_idx` em `userId`, `session_token_unique` em `token`.
+
+### `account`
+
+| Campo | Tipo Drizzle | Restricoes |
+|-------|-------------|-----------|
+| `id` | `text("id")` | PK |
+| `accountId` | `text("account_id")` | NOT NULL |
+| `providerId` | `text("provider_id")` | NOT NULL |
+| `userId` | `text("user_id")` | NOT NULL, FK → `user.id` CASCADE |
+| `accessToken` | `text("access_token")` | — |
+| `refreshToken` | `text("refresh_token")` | — |
+| `idToken` | `text("id_token")` | — |
+| `accessTokenExpiresAt` | `integer("access_token_expires_at", { mode: "timestamp_ms" })` | — |
+| `refreshTokenExpiresAt` | `integer("refresh_token_expires_at", { mode: "timestamp_ms" })` | — |
+| `scope` | `text("scope")` | — |
+| `password` | `text("password")` | — |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update |
+
+Indices: `account_userId_idx` em `userId`, `account_provider_account_unique` em (`providerId`, `accountId`).
+
+### `verification`
+
+| Campo | Tipo Drizzle | Restricoes |
+|-------|-------------|-----------|
+| `id` | `text("id")` | PK |
+| `identifier` | `text("identifier")` | NOT NULL |
+| `value` | `text("value")` | NOT NULL |
+| `expiresAt` | `integer("expires_at", { mode: "timestamp_ms" })` | NOT NULL |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update |
+
+Indices: `verification_identifier_idx` em `identifier`.
+
+### Relations (Auth)
+
+```
+user 1 ──→ N session
+user 1 ──→ N account
+```
+
+---
+
+## Tabelas Novas
+
+### `profile` (em `profile.schema.ts`)
+
+Perfil publico do usuario. Relacao 1:1 com `user`.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID gerado pela aplicacao |
+| `userId` | `text("user_id")` | NOT NULL, UNIQUE, FK → `user.id` CASCADE | Vinculo com tabela auth |
+| `username` | `text("username")` | NOT NULL, UNIQUE | Username do Discord — identificador publico, usado na URL |
+| `displayName` | `text("display_name")` | — | Nome de exibicao (pode ser diferente do Discord) |
+| `bio` | `text("bio")` | — | Bio curta do usuario |
+| `avatarUrl` | `text("avatar_url")` | — | URL do avatar (usa o do Discord por padrao) |
+| `website` | `text("website")` | — | Site pessoal |
+| `github` | `text("github")` | — | Username do GitHub |
+| `twitter` | `text("twitter")` | — | Handle do X/Twitter |
+| `linkedin` | `text("linkedin")` | — | URL do LinkedIn |
+| `interests` | `text("interests", { mode: "json" })` | — | Array JSON de areas de interesse |
+| `isOnboardingComplete` | `integer("is_onboarding_complete", { mode: "boolean" })` | NOT NULL, default `false` | Controle de fluxo do onboarding |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
+
+**Indices:**
+- `profile_userId_unique` em `userId` (UNIQUE)
+- `profile_username_unique` em `username` (UNIQUE)
+
+**Relations:**
+```
+user 1 ──→ 1 profile
+profile 1 ──→ N project_members (via userId)
+```
+
+---
+
+### `projects` (em `projects.schema.ts`)
+
+Projetos publicados pelos membros da comunidade.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `name` | `text("name")` | NOT NULL | Nome do projeto |
+| `slug` | `text("slug")` | NOT NULL, UNIQUE | Slug para URL (gerado a partir do nome) |
+| `description` | `text("description")` | — | Descricao detalhada do projeto |
+| `url` | `text("url")` | — | URL do projeto/produto |
+| `logoUrl` | `text("logo_url")` | — | URL do logo |
+| `category` | `text("category")` | NOT NULL, default `"outro"` | `app` / `saas` / `micro_saas` / `startup` / `outro` |
+| `status` | `text("status")` | NOT NULL, default `"ideia"` | `ideia` / `construindo` / `lancado` / `adquirido` |
+| `tags` | `text("tags", { mode: "json" })` | — | Array JSON de tags |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
+
+**Indices:**
+- `projects_slug_unique` em `slug` (UNIQUE)
+
+---
+
+### `project_members` (em `projects.schema.ts`)
+
+Tabela de juncao para membros de um projeto com seus papeis. Vive dentro de `projects.schema.ts` por ser interna ao dominio de projetos.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `projectId` | `text("project_id")` | NOT NULL, FK → `projects.id` CASCADE | |
+| `userId` | `text("user_id")` | NOT NULL, FK → `user.id` CASCADE | |
+| `role` | `text("role")` | NOT NULL, default `"contributor"` | `owner` / `contributor` |
+| `joinedAt` | `integer("joined_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+
+**Indices:**
+- `project_members_project_user_unique` em (`projectId`, `userId`) (UNIQUE)
+- `project_members_project_idx` em `projectId`
+- `project_members_user_idx` em `userId`
+
+**Regras de negocio:**
+- Cada projeto tem exatamente 1 membro com `role = "owner"` (criado automaticamente ao criar o projeto)
+- Pode ter N membros com `role = "contributor"` (adicionados pelo owner)
+- O owner e o unico que pode editar/excluir o projeto e gerenciar colaboradores
+
+**Relations:**
+```
+projects 1 ──→ N project_members
+user 1 ──→ N project_members
+```
+
+---
+
+### `events` (em `events.schema.ts`)
+
+Eventos da comunidade e parceiros.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `name` | `text("name")` | NOT NULL | Nome do evento |
+| `description` | `text("description")` | — | Descricao curta |
+| `date` | `integer("date", { mode: "timestamp_ms" })` | NOT NULL | Data e horario do evento |
+| `format` | `text("format")` | NOT NULL | `presencial` / `digital` |
+| `address` | `text("address")` | — | Endereco completo (somente se presencial) |
+| `accessLink` | `text("access_link")` | — | Link de acesso (somente se digital) |
+| `eventLink` | `text("event_link")` | NOT NULL | Link para pagina oficial do evento |
+| `bannerUrl` | `text("banner_url")` | — | Banner/imagem do evento |
+| `organizerName` | `text("organizer_name")` | NOT NULL | Nome do organizador |
+| `isPartner` | `integer("is_partner", { mode: "boolean" })` | NOT NULL, default `false` | Se e parceiro externo (true) ou a propria comunidade (false) |
+| `createdBy` | `text("created_by")` | NOT NULL, FK → `user.id` CASCADE | Admin que cadastrou |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
+
+**Indices:**
+- `events_date_idx` em `date` (para ordenar proximos/passados)
+- `events_createdBy_idx` em `createdBy`
+
+---
+
+### `event_members` (em `events.schema.ts`)
+
+Tabela reservada para o futuro sistema de RSVP. Criada agora para evitar migrations complexas depois, mas **nenhuma funcionalidade de RSVP sera exposta nesta versao**.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `eventId` | `text("event_id")` | NOT NULL, FK → `events.id` CASCADE | |
+| `userId` | `text("user_id")` | NOT NULL, FK → `user.id` CASCADE | |
+| `status` | `text("status")` | NOT NULL, default `"interessado"` | `interessado` / `nao_vou` / `confirmado` |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+
+**Indices:**
+- `event_members_event_user_unique` em (`eventId`, `userId`) (UNIQUE)
+
+**Relations:**
+```
+events 1 ──→ N event_members
+user 1 ──→ N event_members
+```
+
+---
+
+### `posts` (em `posts.schema.ts`)
+
+Posts do feed — comunicados de admin e atualizacoes de Build In Public.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `authorId` | `text("author_id")` | NOT NULL, FK → `user.id` CASCADE | Autor do post |
+| `type` | `text("type")` | NOT NULL | `announcement` / `build_in_public` |
+| `content` | `text("content")` | NOT NULL | Texto com suporte a Markdown |
+| `imageUrl` | `text("image_url")` | — | Imagem opcional |
+| `projectId` | `text("project_id")` | FK → `projects.id` SET NULL | Projeto vinculado (opcional, para posts BIP) |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+
+**Nota**: posts nao tem `updatedAt` — sao imutaveis apos publicacao. Se necessario editar, o autor pode excluir e recriar.
+
+**Indices:**
+- `posts_authorId_idx` em `authorId`
+- `posts_projectId_idx` em `projectId`
+- `posts_createdAt_idx` em `createdAt` (para paginacao cronologica)
+- `posts_type_idx` em `type` (para filtro por tipo)
+
+**Relations:**
+```
+user 1 ──→ N posts
+projects 1 ──→ N posts (opcional)
+```
+
+---
+
+### `follows` (em `follows.schema.ts`)
+
+Tabela polimorfica para seguir usuarios e projetos. Em arquivo proprio porque cruza dominios.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `followerId` | `text("follower_id")` | NOT NULL, FK → `user.id` CASCADE | Quem esta seguindo |
+| `targetType` | `text("target_type")` | NOT NULL | `user` / `project` |
+| `targetId` | `text("target_id")` | NOT NULL | ID do usuario ou projeto seguido |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+
+**Indices:**
+- `follows_follower_target_unique` em (`followerId`, `targetType`, `targetId`) (UNIQUE — evita follows duplicados)
+- `follows_followerId_idx` em `followerId`
+- `follows_target_idx` em (`targetType`, `targetId`) (para contar seguidores de um alvo)
+
+**Nota sobre FK polimorfica**: `targetId` nao tem FK no banco porque aponta para tabelas diferentes conforme `targetType`. A integridade e garantida pela aplicacao. Alternativamente, pode-se criar duas tabelas separadas (`user_follows` e `project_follows`), mas a abordagem polimorfica e mais simples e suficiente para o escopo atual.
+
+**Relations:**
+```
+user 1 ──→ N follows (como follower)
+user/project ←── N follows (como target)
+```
+
+---
+
+### `recommendations` (em `recommendations.schema.ts`)
+
+Endosso publico de um usuario para um projeto. Em arquivo proprio porque cruza dominios.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `userId` | `text("user_id")` | NOT NULL, FK → `user.id` CASCADE | Quem esta recomendando |
+| `projectId` | `text("project_id")` | NOT NULL, FK → `projects.id` CASCADE | Projeto recomendado |
+| `message` | `text("message")` | — | Texto curto opcional explicando a recomendacao |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+
+**Indices:**
+- `recommendations_user_project_unique` em (`userId`, `projectId`) (UNIQUE — um usuario so pode recomendar o mesmo projeto uma vez)
+- `recommendations_projectId_idx` em `projectId` (para listar recomendacoes de um projeto)
+
+**Regras de negocio:**
+- O owner do projeto **nao pode** recomendar o proprio projeto (validacao na aplicacao)
+- A recomendacao e publica e aparece na pagina do projeto
+
+**Relations:**
+```
+user 1 ──→ N recommendations
+projects 1 ──→ N recommendations
+```
+
+---
+
+### `comments` (em `comments.schema.ts`)
+
+Comentarios e avaliacoes em projetos. Em arquivo proprio porque cruza dominios.
+
+| Campo | Tipo Drizzle | Restricoes | Descricao |
+|-------|-------------|-----------|-----------|
+| `id` | `text("id")` | PK | UUID |
+| `authorId` | `text("author_id")` | NOT NULL, FK → `user.id` CASCADE | Autor do comentario |
+| `projectId` | `text("project_id")` | NOT NULL, FK → `projects.id` CASCADE | Projeto comentado |
+| `content` | `text("content")` | NOT NULL | Texto do comentario (Markdown) |
+| `rating` | `integer("rating")` | — | Avaliacao de 1 a 5 (opcional) |
+| `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
+| `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
+
+**Indices:**
+- `comments_projectId_idx` em `projectId`
+- `comments_authorId_idx` em `authorId`
+- `comments_rating_unique` em (`authorId`, `projectId`) onde `rating IS NOT NULL` — logica: um usuario pode deixar multiplos comentarios, mas apenas **uma avaliacao (rating)** por projeto
+
+**Nota sobre rating unico**: SQLite nao suporta indices parciais com WHERE nativamente no Drizzle. A unicidade do rating por usuario/projeto deve ser garantida na camada de aplicacao:
+- Ao submeter um comentario com rating, verificar se o usuario ja tem um rating para aquele projeto
+- Se ja existir, atualizar o rating existente em vez de criar um novo
+- Comentarios sem rating podem ser ilimitados
+
+**Relations:**
+```
+user 1 ──→ N comments
+projects 1 ──→ N comments
+```
+
+---
+
+## Diagrama de Relacionamentos
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         AUTH (existente)                            │
+│                                                                     │
+│  ┌────────┐    1:N    ┌──────────┐                                 │
+│  │  user  │──────────→│ session  │                                 │
+│  │        │           └──────────┘                                 │
+│  │        │    1:N    ┌──────────┐                                 │
+│  │        │──────────→│ account  │                                 │
+│  └────┬───┘           └──────────┘                                 │
+│       │                                                             │
+└───────┼─────────────────────────────────────────────────────────────┘
+        │
+        │ 1:1
+        ▼
+  ┌──────────┐
+  │ profile  │
+  └──────────┘
+        │
+        │ (via user.id)
+        ▼
+   ┌─────────────────────────────────────────────────────┐
+   │                                                     │
+   │    ┌──────────┐    1:N    ┌─────────────────┐      │
+   │    │ projects │──────────→│ project_members  │←── user
+   │    │          │           └─────────────────┘      │
+   │    └────┬─────┘                                    │
+   │         │                                          │
+   │         │ 1:N         1:N         1:N              │
+   │         ├────────→ posts ←──── user                │
+   │         ├────────→ recommendations ←── user        │
+   │         ├────────→ comments ←── user                │
+   │         └────────→ follows (target) ←── user       │
+   │                                                     │
+   │    ┌──────────┐    1:N    ┌─────────────────┐      │
+   │    │ events   │──────────→│ event_members   │←── user
+   │    └──────────┘           └─────────────────┘      │
+   │                                                     │
+   │    follows (user target) ←── user                   │
+   │                                                     │
+   └─────────────────────────────────────────────────────┘
+```
+
+### Resumo de Relacionamentos
+
+| De | Para | Tipo | Via |
+|----|------|------|-----|
+| `user` | `profile` | 1:1 | `profile.userId` |
+| `user` | `project_members` | 1:N | `project_members.userId` |
+| `projects` | `project_members` | 1:N | `project_members.projectId` |
+| `user` | `events` | 1:N | `events.createdBy` |
+| `events` | `event_members` | 1:N | `event_members.eventId` |
+| `user` | `event_members` | 1:N | `event_members.userId` |
+| `user` | `posts` | 1:N | `posts.authorId` |
+| `projects` | `posts` | 1:N | `posts.projectId` (opcional) |
+| `user` | `follows` | 1:N | `follows.followerId` |
+| `user` | `recommendations` | 1:N | `recommendations.userId` |
+| `projects` | `recommendations` | 1:N | `recommendations.projectId` |
+| `user` | `comments` | 1:N | `comments.authorId` |
+| `projects` | `comments` | 1:N | `comments.projectId` |
+
+## Pontos em Aberto
+
+- **Geracao de IDs**: definir se usaremos `crypto.randomUUID()` (disponivel em Cloudflare Workers) ou uma lib como `nanoid`. O `auth.schema.ts` delega a geracao ao Better-Auth — para os novos schemas, a aplicacao sera responsavel.
+- **Soft delete**: nenhuma tabela usa soft delete no momento. Se necessario no futuro (ex.: projetos excluidos que precisam manter historico), adicionar campo `deletedAt` nas tabelas relevantes.
+- **Full-text search**: SQLite suporta FTS5 para busca textual. Se busca global for implementada no futuro, considerar criar tabelas virtuais FTS para projetos, perfis e posts.

--- a/src/docs/stack-tecnica.md
+++ b/src/docs/stack-tecnica.md
@@ -1,0 +1,304 @@
+# Stack Tecnica
+
+## Visao Geral da Arquitetura
+
+```
+[Navegador] <---> [Cloudflare Workers (Edge)] <---> [Cloudflare D1 (SQLite)]
+                         |
+                   TanStack Start
+                   (SSR + API Routes)
+                         |
+                   Better-Auth (Discord OAuth)
+```
+
+A aplicacao roda inteiramente no edge via Cloudflare Workers. Nao ha servidor de origem — tudo e processado nos data centers da Cloudflare mais proximos do usuario.
+
+## Framework e Roteamento
+
+### TanStack Start
+
+- **Framework**: [TanStack Start](https://tanstack.com/start) com React 19 e Vite 7
+- **Tipo**: Full-stack com SSR (Server-Side Rendering)
+- **Roteamento**: File-based via TanStack Router
+
+### Convencoes de Roteamento
+
+O projeto usa tokens customizados para nomes de arquivo de rota:
+
+| Tipo | Nome do arquivo | Exemplo |
+|------|----------------|---------|
+| Pagina (index) | `page.tsx` | `src/routes/page.tsx` → `/` |
+| Layout | `layout.tsx` | `src/routes/layout.tsx` |
+| Rota dinamica | `$param/page.tsx` | `src/routes/projetos/$slug/page.tsx` → `/projetos/:slug` |
+| API Route | `$.ts` | `src/routes/api/auth/$.ts` → `/api/auth/*` |
+
+**Importante**: o projeto usa `page.tsx` (nao `index.tsx`) e `layout.tsx` (nao `_layout.tsx`). Isso e configurado no `vite.config.ts` com `indexToken: "page"` e `routeToken: "layout"`.
+
+A rota raiz e a excecao: `src/routes/__root.tsx` continua com o nome padrao do TanStack Router.
+
+### Estrutura de Rotas Atual
+
+```
+src/routes/
+├── __root.tsx          # Layout raiz (ThemeProvider, Toaster, DevTools)
+├── page.tsx            # Homepage (/)
+└── api/
+    └── auth/
+        └── $.ts        # Better-Auth handler (/api/auth/*)
+```
+
+## Runtime e Deploy
+
+### Cloudflare Workers
+
+- **Runtime**: Cloudflare Workers (edge, V8 isolates)
+- **Plugin Vite**: `@cloudflare/vite-plugin`
+- **Compatibilidade**: `compatibility_date: "2025-09-02"`, `nodejs_compat` habilitado
+- **Configuracao**: `wrangler.jsonc` na raiz do projeto
+- **Observabilidade**: habilitada no wrangler (`observability.enabled: true`)
+
+### Banco de Dados
+
+- **Servico**: Cloudflare D1 (SQLite distribuido no edge)
+- **Binding**: `DB` (acessivel via `env.DB` no worker)
+- **Nome do banco**: `indiehackersbrasil-db`
+- **Migrations**: `src/lib/db/migrations/`
+
+## ORM — Drizzle
+
+### Configuracao
+
+- **Dialeto**: SQLite
+- **Driver**: D1 HTTP
+- **Arquivo de config**: `drizzle.config.ts`
+- **Schema**: `src/lib/db/schema/index.ts` (barrel file que re-exporta todos os schemas)
+- **Migrations**: `src/lib/db/migrations/`
+
+### Acesso ao Banco
+
+O banco e acessado via a funcao `getDb()` em `src/lib/db/index.ts`, que le o binding `DB` do ambiente Cloudflare.
+
+### Convencoes de Tipos SQLite/Drizzle
+
+O SQLite tem um sistema de tipos limitado. O Drizzle abstrai isso com modos tipados:
+
+| Conceito | Drizzle/SQLite | NAO usar (PostgreSQL) |
+|----------|---------------|----------------------|
+| String | `text("col")` | `varchar("col", { length: 255 })` |
+| Inteiro | `integer("col")` | `serial("col")`, `bigint` |
+| Booleano | `integer("col", { mode: "boolean" })` | `boolean("col")` |
+| Timestamp | `integer("col", { mode: "timestamp_ms" })` | `timestamp("col")` |
+| JSON | `text("col", { mode: "json" })` | `jsonb("col")` |
+| Chave primaria | `text("id").primaryKey()` | `serial("id").primaryKey()` |
+| Enum-like | `text("status")` + validacao Zod | `pgEnum(...)` |
+| Table builder | `sqliteTable(...)` | `pgTable(...)` |
+
+**Padroes extraidos do `auth.schema.ts` existente:**
+
+```typescript
+// ID — texto, chave primaria (Better-Auth gera UUIDs como string)
+id: text("id").primaryKey()
+
+// Timestamp — inteiro em milissegundos Unix
+createdAt: integer("created_at", { mode: "timestamp_ms" })
+  .notNull()
+  .default(sql`(unixepoch() * 1000)`)
+
+// Timestamp com auto-update
+updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+  .notNull()
+  .default(sql`(unixepoch() * 1000)`)
+  .$onUpdate(() => new Date())
+
+// Booleano
+emailVerified: integer("email_verified", { mode: "boolean" })
+  .notNull()
+  .default(false)
+
+// Foreign Key
+userId: text("user_id")
+  .notNull()
+  .references(() => user.id, { onDelete: "cascade" })
+
+// Indices — terceiro argumento do sqliteTable
+(table) => [
+  index("nome_idx").on(table.campo),
+  uniqueIndex("nome_unique").on(table.campo),
+]
+```
+
+**Naming**: colunas em `snake_case` no banco, propriedades em `camelCase` no TypeScript.
+
+## Autenticacao — Better-Auth
+
+### Configuracao
+
+- **Provedor**: Discord OAuth (unico provedor)
+- **Adapter**: `drizzleAdapter` com `provider: "sqlite"`
+- **Plugin**: `tanstackStartCookies()` para integracao com TanStack Start
+- **Arquivo principal**: `src/lib/auth/index.ts`
+
+### Server Functions
+
+Duas server functions em `src/lib/auth/server.ts`:
+
+```typescript
+// Retorna a sessao ou null
+getSession()
+
+// Retorna a sessao ou lanca Error("Unauthorized")
+ensureSession()
+```
+
+Ambas usam `createServerFn({ method: "GET" })` do TanStack Start e leem headers via `getRequestHeaders()`.
+
+### Client
+
+O cliente de auth e criado em `src/lib/auth/client.ts`:
+
+```typescript
+import { createAuthClient } from "better-auth/react";
+export const authClient = createAuthClient();
+```
+
+Uso no componente:
+
+```typescript
+const { data: session, isPending } = authClient.useSession();
+```
+
+### Dados do Discord
+
+Ao fazer login via Discord, o Better-Auth armazena automaticamente:
+
+- `user.name` — nome de exibicao do Discord
+- `user.email` — email vinculado ao Discord
+- `user.image` — avatar do Discord
+- `account.accountId` — ID numerico do Discord
+- `account.providerId` — `"discord"`
+
+**Nota importante**: o **username do Discord** (handle com @) nao e armazenado diretamente pelo Better-Auth na tabela `user`. O campo `user.name` contem o nome de exibicao (display name), nao o username. Para obter o username do Discord, sera necessario usar a API do Discord via `account.accessToken` ou configurar o Better-Auth com `mapProfileToUser` para incluir o username.
+
+## UI e Estilizacao
+
+### Tailwind CSS 4
+
+- Configurado via `@tailwindcss/vite` plugin
+- Variaveis CSS para temas em `src/styles.css`
+- Classes utilitarias padrao do Tailwind
+
+### shadcn/ui
+
+- **Estilo**: `new-york`
+- **Configuracao**: `components.json` na raiz
+- **Componentes**: `src/components/ui/`
+- **30+ componentes instalados**: alert, avatar, badge, breadcrumb, button, card, checkbox, dialog, dropdown-menu, empty, input, kbd, label, navigation-menu, pagination, popover, select, separator, skeleton, spinner, switch, table, tabs, textarea, toggle, toggle-group, tooltip, typography
+- **Comando para adicionar**: `bunx --bun shadcn@latest add <componente>`
+
+### Tema (Dark Mode)
+
+- Gerenciado por `next-themes` com `ThemeProvider` no `__root.tsx`
+- Suporta: `light`, `dark`, `system`
+- Atributo: `class` (adiciona classe no elemento raiz)
+
+### Icones
+
+- **Biblioteca**: Lucide React (`lucide-react`)
+- Importar icones individualmente: `import { NomeDoIcone } from "lucide-react"`
+
+## Alias de Importacao
+
+O projeto usa um unico alias:
+
+```
+@/* → ./src/*
+```
+
+Configurado em `tsconfig.json` (`paths`) e `vite.config.ts` (`resolve.alias`).
+
+**Exemplos de uso:**
+
+```typescript
+import { auth } from "@/lib/auth";
+import { getDb } from "@/lib/db";
+import * as schema from "@/lib/db/schema";
+import { Button } from "@/components/ui/button";
+import { SITE } from "@/data/constants";
+```
+
+**Nota**: o `package.json` tambem define `#/*` como subpath import do Node, mas o codigo do projeto usa `@/*` via TypeScript paths. Usar sempre `@/*`.
+
+## Estrutura de Pastas
+
+```
+src/
+├── components/
+│   └── ui/              # Componentes shadcn/ui
+├── data/
+│   └── constants/       # Constantes (env, site config)
+│       ├── env.ts       # Variaveis de ambiente
+│       ├── site.ts      # Configuracao do site
+│       └── index.ts     # Barrel file
+├── lib/
+│   ├── auth/            # Better-Auth (config, server, client)
+│   ├── db/              # Drizzle ORM (conexao, schemas, migrations)
+│   │   ├── schema/      # Schemas do banco (um arquivo por dominio)
+│   │   └── migrations/  # Migrations geradas pelo Drizzle Kit
+│   └── utils.ts         # Utilitarios (cn para classes)
+├── routes/              # Rotas TanStack Router
+├── router.tsx           # Configuracao do router
+├── routeTree.gen.ts     # Arvore de rotas (auto-gerado)
+└── styles.css           # Estilos globais + variaveis CSS
+```
+
+### Convencao de Schemas
+
+Cada dominio tem seu proprio arquivo em `src/lib/db/schema/`:
+
+- Um arquivo por dominio (ex.: `profile.schema.ts`, `projects.schema.ts`)
+- Tabelas de juncao ficam dentro do schema do dominio que as contem
+- Schemas que cruzam multiplos dominios ganham arquivo proprio (ex.: `follows.schema.ts`)
+- Todos os schemas sao re-exportados pelo `index.ts` do diretorio
+
+Ver [`schema-banco-de-dados.md`](./schema-banco-de-dados.md) para a lista completa de schemas planejados.
+
+## Linting e Formatacao
+
+### Biome
+
+- **Arquivo de config**: `biome.json`
+- **Indentacao**: tabs (nao espacos)
+- **Aspas**: double quotes
+- **Regras**: recommended do Biome habilitadas
+- **Integrado ao editor** (recomendado: extensao Biome no VS Code)
+
+## Scripts Disponiveis
+
+| Script | Comando | Descricao |
+|--------|---------|-----------|
+| `dev` | `vite dev --port 3000` | Servidor de desenvolvimento local |
+| `build` | `vite build` | Build para producao |
+| `deploy` | `bun run build && wrangler deploy` | Build + deploy para Cloudflare |
+| `db:generate` | `drizzle-kit generate` | Gera migrations a partir dos schemas |
+| `db:migrate` | `drizzle-kit migrate` | Aplica migrations pendentes |
+| `db:studio` | `drizzle-kit studio` | Abre o Drizzle Studio (interface web do banco) |
+
+**Package manager**: Bun (`bun run`, `bunx`, `bun.lock`).
+
+## Variaveis de Ambiente
+
+Definidas em `.env` (local) e `.env.example` (template):
+
+| Variavel | Descricao |
+|----------|-----------|
+| `CLOUDFLARE_ACCOUNT_ID` | ID da conta Cloudflare |
+| `CLOUDFLARE_DATABASE_ID` | ID do banco D1 |
+| `CLOUDFLARE_D1_TOKEN` | Token de API para acesso ao D1 |
+| `BETTER_AUTH_SECRET` | Secret para assinatura de tokens |
+| `BETTER_AUTH_URL` | URL base da aplicacao (ex.: `http://localhost:3000`) |
+| `DISCORD_CLIENT_ID` | Client ID do app Discord OAuth |
+| `DISCORD_CLIENT_SECRET` | Client Secret do app Discord OAuth |
+| `RESEND_API_KEY` | API key do Resend (email — reservado para uso futuro) |
+| `RESEND_FROM` | Remetente padrao de emails |
+
+As variaveis sao acessadas via `src/data/constants/env.ts`, que as le do `process.env`.

--- a/src/docs/visao-geral.md
+++ b/src/docs/visao-geral.md
@@ -1,0 +1,98 @@
+# Visao Geral da Plataforma
+
+## O que e o Indie Hacking Brasil
+
+O **Indie Hacking Brasil** e uma comunidade brasileira com mais de 12 mil membros no Discord, reunindo pessoas que estao construindo seus proprios produtos digitais — Apps, SaaS, Micro-SaaS e Startups — com foco em networking, troca de conhecimento e cultura de Build In Public.
+
+Esta plataforma web serve como **complemento ao Discord**, oferecendo funcionalidades que o Discord nao suporta bem: perfis publicos permanentes, vitrine de projetos, historico de atualizacoes e visibilidade para quem esta fora do servidor.
+
+## Proposito e Objetivos
+
+A plataforma existe para:
+
+1. **Dar visibilidade aos membros e seus projetos** — perfis publicos e paginas de projeto indexaveis, compartilhaveis e com URL permanente.
+2. **Registrar a jornada de Build In Public** — um feed cronologico onde membros compartilham atualizacoes dos seus projetos, criando um historico que nao se perde no fluxo do Discord.
+3. **Divulgar eventos da comunidade** — uma vitrine centralizada de meetups, lives, workshops e hackathons.
+4. **Facilitar conexoes** — funcionalidades sociais como seguir usuarios, recomendar projetos e comentar em projetos de outros membros.
+5. **Servir como porta de entrada** — visitantes podem conhecer a comunidade, ver projetos e perfis, e ser incentivados a entrar no Discord.
+
+## Publico-alvo
+
+- **Solo founders** e **indie hackers** brasileiros construindo produtos digitais
+- **Desenvolvedores** que querem compartilhar seus side projects e receber feedback
+- **Empreendedores** em estagio inicial buscando networking e validacao
+- **Curiosos e aspirantes** que querem conhecer a comunidade antes de entrar no Discord
+
+## Relacao com a Comunidade no Discord
+
+O Discord continua sendo o **centro de comunicacao em tempo real** da comunidade. A plataforma web nao substitui o Discord — ela o complementa:
+
+| Discord | Plataforma Web |
+|---------|---------------|
+| Conversas em tempo real | Conteudo permanente e indexavel |
+| Canais tematicos | Perfis publicos e paginas de projeto |
+| Efemero por natureza | Historico persistente de BIP |
+| Fechado (precisa entrar no servidor) | Aberto (visitantes veem conteudo publico) |
+| Autenticacao propria | Login via Discord OAuth |
+
+O **login na plataforma e feito exclusivamente via Discord**, reforçando o vinculo entre os dois ambientes. O username do Discord e herdado automaticamente como identificador do usuario na plataforma.
+
+## Principios e Valores
+
+### Edge-first
+A plataforma roda em Cloudflare Workers com banco de dados D1 (SQLite), garantindo latencia minima para usuarios no Brasil e no mundo. Toda a arquitetura e pensada para o edge.
+
+### Simplicidade
+Sem algoritmos, sem gamificacao excessiva, sem metricas de vaidade. O feed e cronologico. As funcionalidades sao diretas. A interface e limpa.
+
+### Portugues-primeiro
+Toda a interface, documentacao e conteudo padrao sao em Portugues do Brasil. A comunidade e brasileira e a plataforma reflete isso.
+
+### Comunidade como base
+Decisoes de produto priorizam o coletivo. A plataforma existe para servir a comunidade, nao para monetizar em cima dela.
+
+### Transparencia
+Build In Public nao e so para os membros — a propria plataforma e construida com transparencia, com codigo aberto e decisoes documentadas.
+
+## Conteudo Condicional por Estado de Autenticacao
+
+A plataforma adota um padrao consistente em todas as paginas: **o conteudo exibido varia de acordo com o estado de autenticacao do usuario**.
+
+### Filosofia
+
+- **Visitante (nao logado)**: ve Landing Pages com apresentacao da comunidade, banners de chamada para o Discord, projetos em destaque e informacoes publicas. O objetivo e apresentar o Indie Hacking Brasil e incentivar o cadastro.
+- **Usuario autenticado**: ve o conteudo real da plataforma — Feed, perfis completos, projetos interativos, etc. — no lugar das Landing Pages.
+
+Esse padrao se aplica a Home, paginas de Perfil, Projetos, Eventos e Feed. O documento dedicado [`conteudo-condicional.md`](./conteudo-condicional.md) detalha o comportamento especifico de cada rota.
+
+### Motivacao
+
+Esse modelo permite que a plataforma funcione simultaneamente como:
+- **Site institucional** para visitantes (SEO, apresentacao, conversao)
+- **Ferramenta de comunidade** para membros autenticados (interacao, conteudo, networking)
+
+## Funcionalidades Principais
+
+A plataforma sera construida em fases incrementais:
+
+1. **[Onboarding e Perfil](./funcionalidades/01-onboarding-perfil.md)** — Perfis publicos com informacoes pessoais, links e areas de interesse.
+2. **[Projetos](./funcionalidades/02-projetos.md)** — Vitrine de projetos com sistema de roles (owner/contributor).
+3. **[Eventos](./funcionalidades/03-eventos.md)** — Divulgacao de eventos da comunidade e parceiros.
+4. **[Feed / Build In Public](./funcionalidades/04-feed.md)** — Feed cronologico com atualizacoes de projeto e comunicados.
+5. **[Funcionalidades Sociais](./funcionalidades/05-social.md)** — Seguir usuarios/projetos, recomendar projetos, comentar e avaliar.
+
+Consulte o [`roadmap.md`](./roadmap.md) para a ordem de desenvolvimento e dependencias entre fases.
+
+## Estado Atual
+
+A infraestrutura base esta pronta:
+
+- TanStack Start (React 19 + Vite) configurado e rodando
+- Deploy em Cloudflare Workers funcional
+- Autenticacao com Discord via Better-Auth operacional
+- Banco de dados D1 com tabelas de auth (user, session, account, verification)
+- 30+ componentes shadcn/ui instalados
+- Tema claro/escuro configurado
+- Biome para linting/formatacao
+
+O que falta: todas as funcionalidades de produto listadas acima. Esta documentacao e o primeiro passo antes da implementacao.

--- a/src/lib/db/migrations/0001_keen_pandemic.sql
+++ b/src/lib/db/migrations/0001_keen_pandemic.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `profile` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`username` text NOT NULL,
+	`display_name` text,
+	`bio` text,
+	`avatar_url` text,
+	`website` text,
+	`github` text,
+	`twitter` text,
+	`linkedin` text,
+	`interests` text,
+	`is_onboarding_complete` integer DEFAULT false NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `profile_userId_unique` ON `profile` (`user_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `profile_username_unique` ON `profile` (`username`);

--- a/src/lib/db/migrations/meta/0001_snapshot.json
+++ b/src/lib/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,520 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f11b275b-f91a-454c-8f62-c3184a849344",
+  "prevId": "9b558230-95ca-483a-9394-882fb01286a5",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_onboarding_complete": {
+          "name": "is_onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "profile_userId_unique": {
+          "name": "profile_userId_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "profile_username_unique": {
+          "name": "profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773602275184,
       "tag": "0000_broken_human_robot",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1773612563670,
+      "tag": "0001_keen_pandemic",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -1,1 +1,2 @@
 export * from "./auth.schema";
+export * from "./profile.schema";

--- a/src/lib/db/schema/profile.schema.ts
+++ b/src/lib/db/schema/profile.schema.ts
@@ -1,0 +1,49 @@
+import { relations, sql } from "drizzle-orm";
+import {
+	integer,
+	sqliteTable,
+	text,
+	uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { user } from "./auth.schema";
+
+export const profile = sqliteTable(
+	"profile",
+	{
+		id: text("id").primaryKey(),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		username: text("username").notNull(),
+		displayName: text("display_name"),
+		bio: text("bio"),
+		avatarUrl: text("avatar_url"),
+		website: text("website"),
+		github: text("github"),
+		twitter: text("twitter"),
+		linkedin: text("linkedin"),
+		interests: text("interests", { mode: "json" }).$type<string[]>(),
+		isOnboardingComplete: integer("is_onboarding_complete", {
+			mode: "boolean",
+		})
+			.notNull()
+			.default(false),
+
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`),
+
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`)
+			.$onUpdate(() => new Date()),
+	},
+	(table) => [
+		uniqueIndex("profile_userId_unique").on(table.userId),
+		uniqueIndex("profile_username_unique").on(table.username),
+	],
+);
+
+export const profileRelations = relations(profile, ({ one }) => ({
+	user: one(user, { fields: [profile.userId], references: [user.id] }),
+}));

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+
+export const INTEREST_OPTIONS = [
+	"mobile",
+	"saas-b2b",
+	"saas-b2c",
+	"micro-saas",
+	"ai-ml",
+	"open-source",
+	"e-commerce",
+	"fintech",
+	"edtech",
+	"healthtech",
+	"devtools",
+	"automacao",
+	"no-code-low-code",
+	"marketing-digital",
+	"comunidades",
+] as const;
+
+export const INTEREST_LABELS: Record<
+	(typeof INTEREST_OPTIONS)[number],
+	string
+> = {
+	mobile: "Mobile (iOS/Android)",
+	"saas-b2b": "SaaS B2B",
+	"saas-b2c": "SaaS B2C",
+	"micro-saas": "Micro-SaaS",
+	"ai-ml": "AI / Machine Learning",
+	"open-source": "Open Source",
+	"e-commerce": "E-commerce",
+	fintech: "Fintech",
+	edtech: "EdTech",
+	healthtech: "HealthTech",
+	devtools: "DevTools",
+	automacao: "Automacao",
+	"no-code-low-code": "No-code / Low-code",
+	"marketing-digital": "Marketing Digital",
+	comunidades: "Comunidades",
+};
+
+export const createProfileSchema = z.object({
+	username: z
+		.string()
+		.min(2, "Username deve ter pelo menos 2 caracteres")
+		.max(32, "Username deve ter no maximo 32 caracteres")
+		.regex(
+			/^[a-z0-9_.]+$/,
+			"Username deve conter apenas letras minusculas, numeros, _ e .",
+		),
+	displayName: z
+		.string()
+		.max(100, "Nome de exibicao deve ter no maximo 100 caracteres")
+		.nullable()
+		.optional(),
+	bio: z
+		.string()
+		.max(280, "Bio deve ter no maximo 280 caracteres")
+		.nullable()
+		.optional(),
+	avatarUrl: z.string().url("URL do avatar invalida").nullable().optional(),
+	website: z.string().url("URL do site invalida").nullable().optional(),
+	github: z
+		.string()
+		.max(39, "Username do GitHub deve ter no maximo 39 caracteres")
+		.nullable()
+		.optional(),
+	twitter: z
+		.string()
+		.max(15, "Handle do Twitter deve ter no maximo 15 caracteres")
+		.nullable()
+		.optional(),
+	linkedin: z.string().url("URL do LinkedIn invalida").nullable().optional(),
+	interests: z.array(z.enum(INTEREST_OPTIONS)).nullable().optional(),
+});
+
+export const updateProfileSchema = createProfileSchema.omit({
+	username: true,
+});
+
+export type CreateProfileInput = z.infer<typeof createProfileSchema>;
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,11 +10,29 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as PageRouteImport } from './routes/page'
+import { Route as OnboardingPageRouteImport } from './routes/onboarding/page'
+import { Route as ConfiguracoesPageRouteImport } from './routes/configuracoes/page'
+import { Route as UUsernamePageRouteImport } from './routes/u/$username/page'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
 const PageRoute = PageRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OnboardingPageRoute = OnboardingPageRouteImport.update({
+  id: '/onboarding/',
+  path: '/onboarding/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConfiguracoesPageRoute = ConfiguracoesPageRouteImport.update({
+  id: '/configuracoes/',
+  path: '/configuracoes/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const UUsernamePageRoute = UUsernamePageRouteImport.update({
+  id: '/u/$username/',
+  path: '/u/$username/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
@@ -25,28 +43,51 @@ const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof PageRoute
+  '/configuracoes/': typeof ConfiguracoesPageRoute
+  '/onboarding/': typeof OnboardingPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/u/$username/': typeof UUsernamePageRoute
 }
 export interface FileRoutesByTo {
   '/': typeof PageRoute
+  '/configuracoes': typeof ConfiguracoesPageRoute
+  '/onboarding': typeof OnboardingPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/u/$username': typeof UUsernamePageRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof PageRoute
+  '/configuracoes/': typeof ConfiguracoesPageRoute
+  '/onboarding/': typeof OnboardingPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
+  '/u/$username/': typeof UUsernamePageRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/api/auth/$'
+  fullPaths:
+    | '/'
+    | '/configuracoes/'
+    | '/onboarding/'
+    | '/api/auth/$'
+    | '/u/$username/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/api/auth/$'
-  id: '__root__' | '/' | '/api/auth/$'
+  to: '/' | '/configuracoes' | '/onboarding' | '/api/auth/$' | '/u/$username'
+  id:
+    | '__root__'
+    | '/'
+    | '/configuracoes/'
+    | '/onboarding/'
+    | '/api/auth/$'
+    | '/u/$username/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   PageRoute: typeof PageRoute
+  ConfiguracoesPageRoute: typeof ConfiguracoesPageRoute
+  OnboardingPageRoute: typeof OnboardingPageRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  UUsernamePageRoute: typeof UUsernamePageRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -56,6 +97,27 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof PageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/onboarding/': {
+      id: '/onboarding/'
+      path: '/onboarding'
+      fullPath: '/onboarding/'
+      preLoaderRoute: typeof OnboardingPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/configuracoes/': {
+      id: '/configuracoes/'
+      path: '/configuracoes'
+      fullPath: '/configuracoes/'
+      preLoaderRoute: typeof ConfiguracoesPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/u/$username/': {
+      id: '/u/$username/'
+      path: '/u/$username'
+      fullPath: '/u/$username/'
+      preLoaderRoute: typeof UUsernamePageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/$': {
@@ -70,7 +132,10 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   PageRoute: PageRoute,
+  ConfiguracoesPageRoute: ConfiguracoesPageRoute,
+  OnboardingPageRoute: OnboardingPageRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
+  UUsernamePageRoute: UUsernamePageRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/configuracoes/page.tsx
+++ b/src/routes/configuracoes/page.tsx
@@ -1,0 +1,85 @@
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { ProfileForm } from "@/components/profile-form";
+import { Button } from "@/components/ui/button";
+import { H1, Muted } from "@/components/ui/typography";
+import { getCurrentUserProfile, updateProfile } from "@/data/services/profile";
+import { getSession } from "@/lib/auth/server";
+
+export const Route = createFileRoute("/configuracoes/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (!session) {
+			throw redirect({ to: "/" });
+		}
+		return { session };
+	},
+	loader: async () => {
+		const userProfile = await getCurrentUserProfile();
+		if (!userProfile) {
+			throw redirect({ to: "/onboarding" });
+		}
+		return { profile: userProfile };
+	},
+	component: SettingsPage,
+});
+
+function SettingsPage() {
+	const { profile } = Route.useLoaderData();
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	return (
+		<main className="mx-auto w-full max-w-xl px-4 py-24">
+			<div className="mb-8 flex items-center justify-between">
+				<div>
+					<H1 className="text-2xl">Configuracoes</H1>
+					<Muted>Edite as informacoes do seu perfil.</Muted>
+				</div>
+				<Button variant="outline" size="sm" asChild>
+					<Link to="/u/$username" params={{ username: profile.username }}>
+						<ExternalLink className="size-3.5" />
+						Ver meu perfil
+					</Link>
+				</Button>
+			</div>
+
+			<div className="mb-6 rounded-md border bg-muted/50 px-4 py-3">
+				<Muted>
+					Username:{" "}
+					<span className="font-medium text-foreground">
+						@{profile.username}
+					</span>
+				</Muted>
+			</div>
+
+			<ProfileForm
+				mode="edit"
+				defaultValues={{
+					displayName: profile.displayName,
+					bio: profile.bio,
+					avatarUrl: profile.avatarUrl,
+					website: profile.website,
+					github: profile.github,
+					twitter: profile.twitter,
+					linkedin: profile.linkedin,
+					interests: (profile.interests ?? []) as string[],
+				}}
+				isSubmitting={isSubmitting}
+				onSubmit={async (data) => {
+					setIsSubmitting(true);
+					try {
+						await updateProfile({ data });
+						toast.success("Perfil atualizado com sucesso!");
+					} catch (error) {
+						toast.error("Erro ao atualizar perfil.");
+						throw error;
+					} finally {
+						setIsSubmitting(false);
+					}
+				}}
+			/>
+		</main>
+	);
+}

--- a/src/routes/onboarding/page.tsx
+++ b/src/routes/onboarding/page.tsx
@@ -1,0 +1,76 @@
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
+import { ProfileForm } from "@/components/profile-form";
+import { H1, P } from "@/components/ui/typography";
+import {
+	createProfile,
+	getDiscordUsername,
+	getProfileByUserId,
+} from "@/data/services/profile";
+import { getSession } from "@/lib/auth/server";
+
+export const Route = createFileRoute("/onboarding/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (!session) {
+			throw redirect({ to: "/" });
+		}
+
+		const userProfile = await getProfileByUserId({ data: session.user.id });
+		if (userProfile?.isOnboardingComplete) {
+			throw redirect({ to: "/" });
+		}
+
+		return { session };
+	},
+	loader: async () => {
+		const discordUsername = await getDiscordUsername();
+		return { discordUsername };
+	},
+	component: OnboardingPage,
+});
+
+function OnboardingPage() {
+	const { session } = Route.useRouteContext();
+	const { discordUsername } = Route.useLoaderData();
+	const navigate = useNavigate();
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	return (
+		<main className="mx-auto w-full max-w-xl px-4 py-24">
+			<div className="mb-8 text-center">
+				<H1>Complete seu perfil</H1>
+				<P className="text-muted-foreground">
+					Preencha as informacoes abaixo para participar da comunidade.
+				</P>
+			</div>
+
+			{!discordUsername && (
+				<div className="mb-6 rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+					Nao foi possivel obter seu username do Discord. Tente fazer login
+					novamente.
+				</div>
+			)}
+
+			<ProfileForm
+				mode="create"
+				defaultValues={{
+					username: discordUsername ?? "",
+					displayName: session.user.name,
+					avatarUrl: session.user.image,
+				}}
+				isSubmitting={isSubmitting}
+				onSubmit={async (data) => {
+					setIsSubmitting(true);
+					try {
+						await createProfile({ data });
+						navigate({ to: "/" });
+					} catch (error) {
+						setIsSubmitting(false);
+						throw error;
+					}
+				}}
+			/>
+		</main>
+	);
+}

--- a/src/routes/page.tsx
+++ b/src/routes/page.tsx
@@ -1,43 +1,58 @@
-import { H1, P } from '@/components/ui/typography';
-import { SITE } from '@/data/constants';
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { LogIn, LogOut } from "lucide-react";
+import { H1, P } from "@/components/ui/typography";
+import { SITE } from "@/data/constants";
+import { getProfileByUserId } from "@/data/services/profile";
 import { authClient } from "@/lib/auth/client";
-import { createFileRoute } from '@tanstack/react-router';
-import { LogIn, LogOut } from 'lucide-react';
+import { getSession } from "@/lib/auth/server";
 
-export const Route = createFileRoute('/')({ component: App })
+export const Route = createFileRoute("/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (session) {
+			const userProfile = await getProfileByUserId({
+				data: session.user.id,
+			});
+			if (!userProfile || !userProfile.isOnboardingComplete) {
+				throw redirect({ to: "/onboarding" });
+			}
+		}
+		return { session };
+	},
+	component: App,
+});
 
 function App() {
+	const { data: session, isPending } = authClient.useSession();
 
-  const { data: session, isPending } = authClient.useSession();
+	const handleSignIn = () => {
+		authClient.signIn.social({
+			provider: SITE.auth.provider,
+			callbackURL: SITE.auth.callbackURL,
+		});
+	};
 
-  const handleSignIn = () => {
-    authClient.signIn.social({
-      provider: SITE.auth.provider,
-      callbackURL: SITE.auth.callbackURL,
-    });
-  };
+	const handleSignOut = () => {
+		authClient.signOut();
+	};
 
-  const handleSignOut = () => {
-    authClient.signOut();
-  };
+	return (
+		<main className="mx-auto w-full max-w-6xl px-4 py-24">
+			<H1 className="text-center">Indie Hacking Brasil</H1>
+			<P className="text-center">Estamos em construcao</P>
 
-  return (
-    <main className='max-w-6xl w-full mx-auto px-4 py-24'>
-      <H1 className='text-center'>Olá mundo! 👋</H1>
-      <P className='text-center'>Estamos em construção</P>
-
-      {isPending ? (
-        <span className="inline-flex sm:ml-auto ">Carregando...</span>
-      ) : (
-        <button
-          type="button"
-          onClick={session ? handleSignOut : handleSignIn}
-          className="cursor-pointer inline-flex gap-1 items-center justify-center sm:ml-auto"
-        >
-          {session ? "Deslogar" : "Acessar"}
-          {session ? <LogOut size={16} /> : <LogIn size={16} />}
-        </button>
-      )}
-    </main>
-  )
+			{isPending ? (
+				<span className="inline-flex sm:ml-auto">Carregando...</span>
+			) : (
+				<button
+					type="button"
+					onClick={session ? handleSignOut : handleSignIn}
+					className="inline-flex cursor-pointer items-center justify-center gap-1 sm:ml-auto"
+				>
+					{session ? "Deslogar" : "Acessar"}
+					{session ? <LogOut size={16} /> : <LogIn size={16} />}
+				</button>
+			)}
+		</main>
+	);
 }

--- a/src/routes/u/$username/page.tsx
+++ b/src/routes/u/$username/page.tsx
@@ -1,0 +1,159 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { AtSign, Github, Globe, Linkedin, Pencil, Twitter } from "lucide-react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { H1, Muted, P } from "@/components/ui/typography";
+import { getProfileByUsername } from "@/data/services/profile";
+import { authClient } from "@/lib/auth/client";
+import { INTEREST_LABELS } from "@/lib/validations/profile";
+
+export const Route = createFileRoute("/u/$username/")({
+	loader: async ({ params }) => {
+		const profileData = await getProfileByUsername({
+			data: params.username,
+		});
+		if (!profileData) {
+			throw notFound();
+		}
+		return { profile: profileData };
+	},
+	component: ProfilePage,
+	notFoundComponent: ProfileNotFound,
+});
+
+function ProfileNotFound() {
+	return (
+		<main className="mx-auto w-full max-w-2xl px-4 py-24 text-center">
+			<H1>Perfil nao encontrado</H1>
+			<P className="text-muted-foreground">
+				O usuario que voce procura nao existe.
+			</P>
+			<Button asChild className="mt-4">
+				<Link to="/">Voltar para o inicio</Link>
+			</Button>
+		</main>
+	);
+}
+
+function ProfilePage() {
+	const { profile } = Route.useLoaderData();
+	const { data: session } = authClient.useSession();
+
+	const isOwnProfile = session?.user?.id === profile.userId;
+	const displayName = profile.displayName || profile.username;
+	const interests = (profile.interests ?? []) as string[];
+
+	const links = [
+		{
+			icon: Globe,
+			value: profile.website,
+			href: profile.website,
+			label: "Site",
+		},
+		{
+			icon: Github,
+			value: profile.github,
+			href: `https://github.com/${profile.github}`,
+			label: "GitHub",
+		},
+		{
+			icon: Twitter,
+			value: profile.twitter,
+			href: `https://x.com/${profile.twitter}`,
+			label: "X / Twitter",
+		},
+		{
+			icon: Linkedin,
+			value: profile.linkedin,
+			href: profile.linkedin,
+			label: "LinkedIn",
+		},
+	].filter(
+		(link): link is typeof link & { value: string; href: string } =>
+			!!link.value,
+	);
+
+	return (
+		<main className="mx-auto w-full max-w-2xl px-4 py-24">
+			<div className="flex items-start gap-6">
+				<Avatar className="size-20">
+					<AvatarImage src={profile.avatarUrl ?? undefined} alt={displayName} />
+					<AvatarFallback className="text-2xl">
+						{displayName[0]?.toUpperCase()}
+					</AvatarFallback>
+				</Avatar>
+
+				<div className="flex-1">
+					<div className="flex items-center gap-3">
+						<H1 className="text-2xl">{displayName}</H1>
+						{isOwnProfile && (
+							<Button variant="outline" size="sm" asChild>
+								<Link to="/configuracoes">
+									<Pencil className="size-3.5" />
+									Editar perfil
+								</Link>
+							</Button>
+						)}
+					</div>
+					<p className="flex items-center gap-1 text-sm text-muted-foreground">
+						<AtSign className="size-3.5" />
+						{profile.username}
+					</p>
+					{profile.bio && <P className="mt-2">{profile.bio}</P>}
+				</div>
+			</div>
+
+			{links.length > 0 && (
+				<>
+					<Separator className="my-6" />
+					<div className="flex flex-wrap gap-3">
+						{links.map((link) => (
+							<Button key={link.label} variant="outline" size="sm" asChild>
+								<a href={link.href} target="_blank" rel="noopener noreferrer">
+									<link.icon className="size-4" />
+									{link.label}
+								</a>
+							</Button>
+						))}
+					</div>
+				</>
+			)}
+
+			{interests.length > 0 && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Areas de interesse</Muted>
+						<div className="flex flex-wrap gap-2">
+							{interests.map((interest) => (
+								<Badge key={interest} variant="secondary">
+									{INTEREST_LABELS[interest as keyof typeof INTEREST_LABELS] ??
+										interest}
+								</Badge>
+							))}
+						</div>
+					</div>
+				</>
+			)}
+
+			<Separator className="my-6" />
+			<div>
+				<Muted className="mb-3">Projetos</Muted>
+				<P className="text-sm text-muted-foreground">Nenhum projeto ainda.</P>
+			</div>
+
+			{!session && (
+				<div className="mt-8 rounded-lg border bg-muted/50 p-6 text-center">
+					<P className="font-medium">
+						Faca parte da comunidade Indie Hacking Brasil
+					</P>
+					<Muted>
+						Entre para ver mais detalhes e interagir com outros membros.
+					</Muted>
+				</div>
+			)}
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary

- Adds complete project documentation in `src/docs/` covering architecture, schema, roadmap, and all 5 feature phases
- Implements Phase 1 onboarding & profile: `profile` table schema + D1 migration, Zod validation, and server functions in `src/data/services/profile.ts`
- Adds three new routes: `/onboarding` (profile creation flow), `/u/$username` (public profile page), and `/configuracoes` (profile settings)
- Adds reusable `ProfileForm` and `InterestSelector` components using existing shadcn/ui primitives
- Discord username is resolved at onboarding time via the stored OAuth `accessToken`; home route now redirects unauthenticated or incomplete users to `/onboarding`

## Test plan

- [x] Login with Discord → redirected to `/onboarding` → form pre-filled with Discord username/avatar
- [x] Submit onboarding form → redirected to `/` (home)
- [ ] Visit `/u/{username}` as visitor → public profile with CTA banner
- [x] Visit `/u/{username}` as authenticated user (own profile) → "Editar perfil" button visible
- [ ] Visit `/configuracoes` → edit form with existing data, toast on save
- [ ] Visit `/onboarding` after profile complete → redirected to `/`
- [ ] Visit `/configuracoes` as visitor → redirected to `/`
- [ ] Visit `/u/nonexistent` → 404 page