### PR TITLE
Docs: Role-based permissions and event approval workflow

### DIFF
--- a/src/docs/conteudo-condicional.md
+++ b/src/docs/conteudo-condicional.md
@@ -10,8 +10,12 @@ A plataforma exibe conteudo diferente dependendo do estado de autenticacao do us
 |--------|-----------|-----------------|
 | **Visitante** | Nao logado | `getSession()` retorna `null` |
 | **Autenticado sem perfil** | Logou via Discord mas nao completou onboarding | Sessao existe, mas `profile` nao existe ou `isOnboardingComplete = false` |
-| **Membro** | Logou e completou onboarding | Sessao existe e `profile.isOnboardingComplete = true` |
-| **Owner/Admin** | Membro com permissoes especiais no contexto | Membro + dono do recurso ou admin da plataforma |
+| **Membro** | Logou e completou onboarding | Sessao existe, `profile.isOnboardingComplete = true` e `profile.role = "member"` |
+| **Moderador** | Membro com role de moderacao | `profile.role = "moderator"` |
+| **Admin** | Administrador da plataforma | `profile.role = "admin"` |
+| **Owner** | Membro dono de um recurso especifico | Membro + dono do projeto/post (independente de role) |
+
+**Nota sobre roles**: o campo `role` na tabela `profile` define permissoes globais na plataforma (`member`, `moderator`, `admin`). O conceito de "Owner" e contextual — refere-se ao dono de um recurso especifico (projeto, post, evento submetido), independente da role global.
 
 ## Implementacao Tecnica
 
@@ -107,11 +111,11 @@ if (!profile || !profile.isOnboardingComplete) {
 
 | Estado | Comportamento |
 |--------|--------------|
-| **Visitante** | Lista de proximos eventos em destaque e eventos passados. Acesso total — eventos sao conteudo publico |
-| **Membro** | Mesma experiencia do visitante (RSVP e funcionalidade futura) |
-| **Admin** | Mesma experiencia + botao "Criar evento" |
+| **Visitante** | Lista de proximos eventos aprovados (`status = approved`) e eventos passados aprovados |
+| **Membro** | Mesma experiencia do visitante + botao "Criar evento" (submete para aprovacao) |
+| **Moderador/Admin** | Veem todos os eventos independente do status, com badge visual indicando `pending`, `approved` ou `rejected`. Fila de eventos pendentes em destaque no topo. Botao "Criar evento" |
 
-**Nota**: eventos sao 100% publicos nesta versao. Nao ha diferenca de conteudo entre visitante e membro autenticado.
+**Nota**: apenas eventos com `status = approved` sao publicos. Eventos `pending` e `rejected` sao visiveis apenas pelo autor e por moderators/admins.
 
 ---
 
@@ -119,9 +123,9 @@ if (!profile || !profile.isOnboardingComplete) {
 
 | Estado | Comportamento |
 |--------|--------------|
-| **Visitante** | Detalhes completos do evento: nome, data, formato, local/link, organizador, banner |
-| **Membro** | Mesma experiencia do visitante |
-| **Admin** | Mesma experiencia + botoes "Editar evento" e "Excluir evento" |
+| **Visitante** | Detalhes completos do evento (somente se `status = approved`). Se nao aprovado, exibe 404 |
+| **Membro** | Se `status = approved`: mesma experiencia do visitante. Se e o autor: ve o evento em qualquer status com indicacao do status atual |
+| **Moderador/Admin** | Ve o evento em qualquer status + botoes "Editar evento", "Excluir evento". Se `status = pending`: botoes "Aprovar" e "Rejeitar" |
 
 ---
 
@@ -131,7 +135,8 @@ if (!profile || !profile.isOnboardingComplete) {
 |--------|--------------|
 | **Visitante** | Redireciona para `/` (a Landing Page) |
 | **Autenticado sem perfil** | Redireciona para `/onboarding` |
-| **Membro** | Feed cronologico com posts BIP e comunicados. Filtro por tipo. Formulario de novo post |
+| **Membro** | Feed cronologico com posts BIP e comunicados. Filtro por tipo. Formulario de novo post (tipo BIP) |
+| **Moderador/Admin** | Mesma experiencia do membro + toggle para criar posts do tipo `announcement` |
 
 **Nota**: o Feed tambem aparece na Home (`/`) para membros autenticados. A rota `/feed` e um atalho direto, util para compartilhar ou bookmarkar.
 
@@ -162,6 +167,6 @@ if (!profile || !profile.isOnboardingComplete) {
 - **`ConditionalContent`**: componente que renderiza conteudo A ou B baseado no estado de auth
 - **`LoginCTA`**: call-to-action padrao para visitantes, com botao de login via Discord
 
-## Pontos em Aberto
+## Decisao Tomada — Sistema de Roles
 
-- **Sistema de admin**: como definir quem e admin? Opcoes: campo `isAdmin` na tabela `profile`, tabela separada de roles, ou lista de IDs no `.env`. Decisao a ser tomada antes de implementar Eventos e Feed (que tem funcionalidades restritas a admins).
+O sistema de permissoes usa o campo `role` na tabela `profile` com tres valores: `member`, `moderator` e `admin`. Ver detalhes em [`01-onboarding-perfil.md`](./funcionalidades/01-onboarding-perfil.md#decisoes-tomadas--sistema-de-roles) e [`schema-banco-de-dados.md`](./schema-banco-de-dados.md#profile-em-profileschemats).

--- a/src/docs/funcionalidades/01-onboarding-perfil.md
+++ b/src/docs/funcionalidades/01-onboarding-perfil.md
@@ -128,6 +128,7 @@ profile
 ├── linkedin
 ├── interests (JSON)
 ├── isOnboardingComplete (boolean)
+├── role (member | moderator | admin, default member)
 ├── createdAt
 └── updatedAt
 ```
@@ -239,6 +240,25 @@ A tabela `account` do Better-Auth ja armazena o `accessToken` do Discord. Durant
 **Por que nao as outras opcoes:**
 - `mapProfileToUser`: campos extras retornados por essa funcao nao sao persistidos na tabela `user` (que nao devemos modificar), e combinar com `databaseHooks` adiciona complexidade desnecessaria ao auth config
 - Plugin `username` do Better-Auth: adiciona colunas a tabela `user` gerenciada pelo Better-Auth, conflitando com a regra de nao modificar `auth.schema.ts`
+
+---
+
+## Decisoes Tomadas — Sistema de Roles
+
+O sistema de permissoes da plataforma espelha as roles da comunidade no Discord. O campo `role` na tabela `profile` define o nivel de acesso do usuario:
+
+| Valor | Descricao |
+|-------|-----------|
+| `member` | Membro comum da comunidade (padrao para todos os usuarios apos onboarding) |
+| `moderator` | Moderador da comunidade — pode aprovar/rejeitar eventos e criar comunicados no feed |
+| `admin` | Administrador da plataforma — todas as permissoes de moderator + gerenciamento geral |
+
+**Atribuicao de roles:**
+- Todo usuario comeca como `member` ao completar o onboarding
+- A role e atribuida manualmente no banco de dados ou via dashboard administrativo (futuro)
+- **Funcionalidade futura**: sincronizacao automatica de roles com o Discord via API, permitindo que roles atribuidas no servidor Discord sejam refletidas na plataforma
+
+**Nota**: o campo `role` nao aparece no formulario de onboarding nem na pagina de configuracoes. Apenas moderators e admins podem alterar roles de outros usuarios (via dashboard futuro).
 
 ---
 

--- a/src/docs/funcionalidades/03-eventos.md
+++ b/src/docs/funcionalidades/03-eventos.md
@@ -2,23 +2,76 @@
 
 ## Visao Geral
 
-O sistema de eventos e uma **vitrine simples** para divulgar eventos da comunidade Indie Hacking Brasil e de parceiros. Nesta versao inicial, **nao ha sistema de RSVP** — o objetivo e apenas informar sobre eventos e direcionar os interessados para a pagina oficial.
+O sistema de eventos e uma **vitrine** para divulgar eventos da comunidade Indie Hacking Brasil e de parceiros. Nesta versao inicial, **nao ha sistema de RSVP** — o objetivo e apenas informar sobre eventos e direcionar os interessados para a pagina oficial.
 
-A criacao e edicao de eventos e **restrita a admins**.
+Qualquer membro autenticado com perfil completo pode **submeter eventos**, mas eles so aparecem publicamente apos **aprovacao de um moderator ou admin**. Moderators e admins podem aprovar, rejeitar, editar e excluir eventos.
 
 ## Comportamento por Estado de Autenticacao
 
 ### Visitante
 
-Ve a listagem e as paginas de eventos normalmente. Eventos sao **conteudo 100% publico** — nao ha diferenca de conteudo entre visitante e membro autenticado nesta versao.
+Ve apenas eventos com `status = approved` na listagem e nas paginas individuais. Eventos pendentes ou rejeitados retornam 404 para visitantes.
 
-### Membro autenticado
+### Membro autenticado (role = member)
 
-Mesma experiencia do visitante. O RSVP e funcionalidade futura.
+Na listagem, ve apenas eventos `approved` (mesma experiencia do visitante) + botao "Criar evento" que submete o evento para aprovacao (status inicial `pending`).
 
-### Admin
+Na pagina individual, se for o **autor** do evento, ve o evento em qualquer status com indicacao visual do status atual (pending, approved, rejected) e motivo da rejeicao se aplicavel.
 
-Mesma experiencia + botoes "Criar evento", "Editar evento" e "Excluir evento".
+### Moderador (role = moderator)
+
+Tudo do membro + ve todos os eventos independente do status na listagem, com badge visual indicando o status. Fila de eventos pendentes em destaque no topo da listagem. Pode aprovar, rejeitar, editar e excluir eventos.
+
+### Admin (role = admin)
+
+Mesmas permissoes do moderador.
+
+---
+
+## Fluxo de Aprovacao
+
+O fluxo de aprovacao garante qualidade nos eventos publicados, permitindo que qualquer membro contribua:
+
+```
+                    ┌─────────────┐
+                    │   Membro    │
+                    │ cria evento │
+                    └──────┬──────┘
+                           │
+                           ▼
+                    ┌─────────────┐
+              ┌─────│   pending   │─────┐
+              │     └─────────────┘     │
+              │                         │
+              ▼                         ▼
+       ┌─────────────┐          ┌─────────────┐
+       │  approved   │          │  rejected   │
+       └─────────────┘          └──────┬──────┘
+              │                        │
+              │                        │ Membro corrige
+              ▼                        │ e resubmete
+        Visivel para                   │
+        todos os                       ▼
+        usuarios              ┌─────────────┐
+                              │   pending   │
+                              │ (novamente) │
+                              └─────────────┘
+```
+
+### Transicoes de Status
+
+| De | Para | Quem | Acao |
+|----|------|------|------|
+| — | `pending` | Membro (qualquer) | Cria evento via `/events/novo` |
+| `pending` | `approved` | Moderator/Admin | Aprova na pagina de revisao |
+| `pending` | `rejected` | Moderator/Admin | Rejeita com motivo opcional |
+| `rejected` | `pending` | Autor do evento | Corrige e resubmete |
+
+**Regras:**
+- Apenas eventos com `status = approved` aparecem na listagem publica
+- O autor pode editar e resubmeter um evento `rejected`, voltando para `pending`
+- Eventos `approved` nao voltam para `pending` (apenas moderator/admin pode editar diretamente)
+- A rejeicao inclui um campo `rejectionReason` opcional para orientar o autor sobre o que corrigir
 
 ---
 
@@ -44,7 +97,12 @@ events
 ├── bannerUrl
 ├── organizerName (NOT NULL)
 ├── isPartner (boolean, default false)
-├── createdBy (FK → user.id — admin que cadastrou)
+├── status (NOT NULL, default "pending")
+│   valores: pending | approved | rejected
+├── rejectionReason (motivo da rejeicao, preenchido por moderator/admin)
+├── submittedBy (FK → user.id — membro que submeteu o evento)
+├── reviewedBy (FK → user.id — moderator/admin que revisou)
+├── reviewedAt (data da revisao)
 ├── createdAt
 └── updatedAt
 ```
@@ -91,13 +149,23 @@ Isso permite diferenciar visualmente eventos da comunidade de eventos de parceir
 
 ### `/events` — `src/routes/events/page.tsx`
 
-Listagem de eventos, dividida em duas secoes:
+Listagem de eventos.
+
+**Visitantes e membros (role = member):**
+Dividida em duas secoes, exibindo apenas eventos com `status = approved`:
 
 1. **Proximos eventos**: eventos com `date` no futuro, ordenados por data (mais proximo primeiro)
 2. **Eventos passados**: eventos com `date` no passado, ordenados por data (mais recente primeiro)
 
-- Admins veem botao "Criar evento" no topo
+- Membros veem botao "Criar evento" no topo
 - Nao ha paginacao nesta versao (volume baixo esperado)
+
+**Moderators e admins:**
+Mesma estrutura + secao adicional no topo:
+
+3. **Fila de aprovacao**: eventos com `status = pending`, ordenados por data de submissao (mais antigo primeiro)
+
+Todos os eventos exibem badge visual indicando o status: `pending` (amarelo), `approved` (verde), `rejected` (vermelho).
 
 ### `/events/:id` — `src/routes/events/$id/page.tsx`
 
@@ -105,38 +173,67 @@ Pagina individual do evento.
 
 **Secoes:**
 1. **Banner** (se houver imagem)
-2. **Header**: nome do evento, data formatada, formato badge
-3. **Detalhes**: descricao, local ou link de acesso conforme formato
-4. **Organizador**: nome, badge de comunidade ou parceiro
-5. **CTA**: botao "Ver pagina oficial" linkando para `eventLink`
-6. **Acoes de admin**: botoes editar/excluir (visivel apenas para admins)
+2. **Status badge** (visivel para o autor e moderators/admins se `status != approved`)
+3. **Header**: nome do evento, data formatada, formato badge
+4. **Detalhes**: descricao, local ou link de acesso conforme formato
+5. **Organizador**: nome, badge de comunidade ou parceiro
+6. **CTA**: botao "Ver pagina oficial" linkando para `eventLink`
+7. **Motivo da rejeicao** (visivel apenas se `status = rejected`, para o autor e moderators/admins)
+8. **Acoes de moderacao**: botoes editar/excluir (visivel para moderators e admins)
+
+**Regras de acesso:**
+- `status = approved`: publico para todos
+- `status = pending` ou `rejected`: acessivel apenas pelo autor (campo `submittedBy`) e por moderators/admins. Para outros usuarios, retorna 404
 
 ### `/events/novo` — `src/routes/events/novo/page.tsx`
 
-Formulario de criacao. Restrito a admins.
+Formulario de criacao de evento. Acessivel para qualquer membro autenticado com perfil completo.
+
+O evento criado inicia com `status = pending` e fica aguardando aprovacao.
 
 ### `/events/:id/editar` — `src/routes/events/$id/editar/page.tsx`
 
-Formulario de edicao. Restrito a admins.
+Formulario de edicao. Acessivel para:
+- O autor do evento (se `status = rejected`, permitindo correcao e resubmissao)
+- Moderators e admins (podem editar qualquer evento em qualquer status)
+
+### `/events/:id/revisao` — `src/routes/events/$id/revisao/page.tsx`
+
+Pagina de revisao de evento. Visivel apenas para moderators e admins.
+
+**Secoes:**
+1. Detalhes completos do evento (preview de como ficara publicado)
+2. Informacoes do autor (nome, username, link para perfil)
+3. Botao "Aprovar" — muda status para `approved`
+4. Botao "Rejeitar" — abre campo para motivo opcional, muda status para `rejected`
 
 ---
 
 ## Server Functions
 
-### `createEvent(adminUserId: string, data: CreateEventInput)`
-Cria evento. Verifica se o usuario e admin.
+### `createEvent(userId: string, data: CreateEventInput)`
+Cria evento com `status = "pending"` e `submittedBy = userId`. Qualquer membro com perfil completo pode chamar.
 
-### `updateEvent(eventId: string, adminUserId: string, data: UpdateEventInput)`
-Atualiza evento. Verifica se o usuario e admin.
+### `updateEvent(eventId: string, userId: string, data: UpdateEventInput)`
+Atualiza evento. Permite se o usuario e moderator, admin, ou o autor (se `status = rejected`).
 
-### `deleteEvent(eventId: string, adminUserId: string)`
-Exclui evento. Verifica se o usuario e admin.
+### `deleteEvent(eventId: string, userId: string)`
+Exclui evento. Permite se o usuario e moderator ou admin.
 
-### `getEventById(eventId: string)`
-Busca evento por ID com todos os detalhes.
+### `approveEvent(eventId: string, reviewerId: string)`
+Muda status para `approved`. Registra `reviewedBy` e `reviewedAt`. Apenas moderator ou admin.
 
-### `listEvents()`
-Lista todos os eventos, separados em proximos e passados.
+### `rejectEvent(eventId: string, reviewerId: string, reason?: string)`
+Muda status para `rejected`. Registra `rejectionReason`, `reviewedBy` e `reviewedAt`. Apenas moderator ou admin.
+
+### `resubmitEvent(eventId: string, userId: string)`
+Volta status para `pending`. Limpa `rejectionReason`, `reviewedBy` e `reviewedAt`. Apenas o autor do evento pode chamar, e somente se `status = rejected`.
+
+### `getEventById(eventId: string, requesterId?: string)`
+Busca evento por ID. Se o evento nao e `approved`, retorna apenas se `requesterId` e o autor ou um moderator/admin.
+
+### `listEvents(requesterId?: string, requesterRole?: string)`
+Lista eventos. Visitantes e membros recebem apenas `approved`. Moderators e admins recebem todos os status. Separados em proximos e passados (e pendentes, para moderators/admins).
 
 ---
 
@@ -163,7 +260,7 @@ Validacao condicional: `address` e obrigatorio quando `format = "presencial"`, `
 ## Componentes
 
 ### `EventCard`
-Card de evento para listagem. Exibe: nome, data formatada, formato badge, organizador, badge de comunidade/parceiro.
+Card de evento para listagem. Exibe: nome, data formatada, formato badge, organizador, badge de comunidade/parceiro. Para moderators/admins, inclui badge de status (`pending`/`approved`/`rejected`).
 
 ### `EventForm`
 Formulario de criacao/edicao. Campos condicionais baseados no formato selecionado (presencial mostra campo de endereco, digital mostra campo de link de acesso).
@@ -173,6 +270,15 @@ Badge visual indicando se o evento e presencial ou digital.
 
 ### `EventPartnerBadge`
 Badge indicando se e evento da comunidade ou de parceiro.
+
+### `EventStatusBadge`
+Badge indicando o status de aprovacao do evento: `pending` (amarelo), `approved` (verde), `rejected` (vermelho).
+
+### `EventReviewPanel`
+Painel de revisao com botoes de aprovar e rejeitar + campo de motivo para rejeicao. Usado na pagina `/events/:id/revisao`.
+
+### `EventRejectionNotice`
+Alerta exibido ao autor quando o evento foi rejeitado, mostrando o motivo da rejeicao e botao para editar e resubmeter.
 
 ---
 
@@ -188,6 +294,6 @@ Usar `Intl.DateTimeFormat("pt-BR", ...)` para formatacao consistente.
 
 ## Pontos em Aberto
 
-- **Sistema de admin**: definicao de como verificar se um usuario e admin (mesmo ponto em aberto do [`conteudo-condicional.md`](../conteudo-condicional.md#pontos-em-aberto))
 - **Upload de banner**: mesma decisao de storage do upload de logo de projetos
 - **Eventos recorrentes**: nao suportado nesta versao. Se necessario, cada ocorrencia seria um evento separado
+- **Notificacao ao autor**: quando o evento e aprovado ou rejeitado, idealmente o autor recebe notificacao. Depende do sistema de notificacoes (funcionalidade futura)

--- a/src/docs/funcionalidades/04-feed.md
+++ b/src/docs/funcionalidades/04-feed.md
@@ -2,7 +2,7 @@
 
 ## Visao Geral
 
-O Feed e o coracao da plataforma — um espaco onde membros compartilham atualizacoes sobre seus projetos (Build In Public) e admins publicam comunicados da comunidade. A exibicao e **cronologica reversa** (mais recente primeiro), sem algoritmo.
+O Feed e o coracao da plataforma — um espaco onde membros compartilham atualizacoes sobre seus projetos (Build In Public) e moderators/admins publicam comunicados da comunidade. A exibicao e **cronologica reversa** (mais recente primeiro), sem algoritmo.
 
 ## Comportamento por Estado de Autenticacao
 
@@ -49,7 +49,7 @@ posts
 
 ### `announcement` — Comunicado
 
-- Criado **apenas por admins**
+- Criado por **moderators e admins** (`profile.role = "moderator"` ou `"admin"`)
 - Aparece com **destaque visual** diferenciado no feed (borda, icone ou cor de fundo distintos)
 - Usado para novidades da comunidade, avisos, mudancas de regra, etc.
 - Nao e vinculado a um projeto
@@ -95,7 +95,7 @@ No topo do feed, formulario inline para criar um novo post:
 - Upload de imagem (opcional)
 - Botao "Publicar"
 
-Admins veem um toggle adicional para marcar o post como `announcement`.
+Moderators e admins veem um toggle adicional para marcar o post como `announcement`.
 
 ---
 
@@ -127,10 +127,10 @@ Rota dedicada do Feed. Protegida (requer auth + perfil completo).
 ## Server Functions
 
 ### `createPost(data: CreatePostInput)`
-Cria post. Se `type = "announcement"`, verifica se o usuario e admin.
+Cria post. Se `type = "announcement"`, verifica se o usuario e moderator ou admin.
 
 ### `deletePost(postId: string, userId: string)`
-Exclui post. Permite se `userId` e o autor do post ou um admin.
+Exclui post. Permite se `userId` e o autor do post, um moderator ou um admin.
 
 ### `listFeed(cursor?: number, limit?: number, type?: string)`
 Lista posts com paginacao cursor-based. Filtra por tipo se especificado.

--- a/src/docs/funcionalidades/05-social.md
+++ b/src/docs/funcionalidades/05-social.md
@@ -196,7 +196,7 @@ Secao "Comentarios e Avaliacoes":
 
 - **Criar comentario**: qualquer membro com perfil completo
 - **Editar comentario**: apenas o autor
-- **Excluir comentario**: autor ou admin
+- **Excluir comentario**: autor, moderator ou admin
 - **Owner do projeto**: pode comentar no proprio projeto (ex.: responder perguntas), mas nao pode se auto-avaliar (rating bloqueado no proprio projeto)
 
 ### Server Functions
@@ -208,7 +208,7 @@ Cria comentario. Se incluir rating, verifica a regra de rating unico.
 Atualiza comentario. Apenas o autor pode editar.
 
 #### `deleteComment(commentId: string, requesterId: string)`
-Exclui comentario. Permite se for o autor ou admin.
+Exclui comentario. Permite se for o autor, moderator ou admin.
 
 #### `getProjectComments(projectId: string, cursor?: number)`
 Lista comentarios do projeto com paginacao cursor-based.

--- a/src/docs/roadmap.md
+++ b/src/docs/roadmap.md
@@ -78,20 +78,21 @@ Todas as fases seguintes dependem do perfil estar implementado, pois `user.id` e
 ### Entregas
 
 - [ ] Criar `events.schema.ts` com tabelas `events` e `event_members`
+- [ ] Adicionar campo `role` na tabela `profile` (sistema de roles: member/moderator/admin)
 - [ ] Gerar e aplicar migration
-- [ ] Definir sistema de admin (como marcar usuarios como admin)
-- [ ] Server functions: CRUD de eventos (admin-only)
+- [ ] Server functions: CRUD de eventos, fluxo de aprovacao (`approveEvent`, `rejectEvent`, `resubmitEvent`)
 - [ ] Validacao Zod com campos condicionais (presencial vs digital)
-- [ ] Rota `/events` com listagem (proximos + passados)
-- [ ] Rota `/events/:id` com pagina individual
-- [ ] Rota `/events/novo` e `/events/:id/editar` (admin-only)
-- [ ] Componentes: EventCard, EventForm, EventFormatBadge
+- [ ] Rota `/events` com listagem (proximos + passados + fila de pendentes para moderators/admins)
+- [ ] Rota `/events/:id` com pagina individual e acesso condicional por status e role
+- [ ] Rota `/events/novo` — acessivel para qualquer membro com perfil completo
+- [ ] Rota `/events/:id/editar` — moderators/admins e autor (se rejeitado)
+- [ ] Rota `/events/:id/revisao` — pagina de revisao para moderators/admins
+- [ ] Componentes: EventCard, EventForm, EventFormatBadge, EventStatusBadge, EventReviewPanel, EventRejectionNotice
 - [ ] Formatacao de datas em pt-BR
 
 ### Dependencias
 
-- Fase 1 (Perfil) — precisa de `user.id` para `createdBy`
-- Sistema de admin definido
+- Fase 1 (Perfil) — precisa de `user.id` para `submittedBy` e `reviewedBy`
 
 ### Nota
 
@@ -121,7 +122,7 @@ A tabela `event_members` e criada nesta fase mas nao e exposta na interface. Fun
 
 - Fase 1 (Perfil) — precisa de `user.id` para `authorId`
 - Fase 2 (Projetos) — para vinculo de post com projeto via `projectId`
-- Sistema de admin — para posts do tipo `announcement`
+- Sistema de roles (Fase 3) — para posts do tipo `announcement` (requer role moderator ou admin)
 
 ---
 
@@ -167,9 +168,18 @@ Funcionalidades planejadas para alem das 5 fases iniciais, sem ordem de priorida
 - Badge de contagem no header
 - Opcoes de preferencia de notificacao
 
+### Sincronizacao de Roles com o Discord
+- Sincronizar automaticamente roles da comunidade no Discord (moderator, admin) com o campo `role` na tabela `profile`
+- Usar a API do Discord para ler roles do servidor e atualizar a plataforma periodicamente ou via webhook
+- Permitir que mudancas de role no Discord sejam refletidas na plataforma sem intervencao manual
+
+### Dashboard Administrativo
+- Interface para gerenciamento de roles de usuarios (atribuir/remover moderator e admin)
+- Visao geral de eventos pendentes de aprovacao
+- Metricas basicas da plataforma (usuarios, projetos, eventos)
+
 ### Integracao com Bot do Discord
-- Notificar no Discord quando: novo projeto publicado, novo evento criado, marcos de BIP
-- Sincronizar roles do Discord com permissoes na plataforma (ex.: role de admin)
+- Notificar no Discord quando: novo projeto publicado, novo evento aprovado, marcos de BIP
 - Comando de bot para consultar perfil/projeto diretamente no Discord
 
 ### Busca Global
@@ -203,6 +213,6 @@ Tarefas que devem ser feitas em paralelo ou entre as fases:
 - [ ] **Responsividade**: garantir que todas as paginas funcionam bem em mobile
 - [ ] **Acessibilidade**: labels, focus management, contraste adequado
 - [ ] **Storage de imagens**: decidir solucao para upload (R2, Uploadthing, ou URL externa)
-- [ ] **Sistema de admin**: definir como identificar admins (campo no profile, env var, ou tabela separada)
+- [x] **Sistema de roles**: decidido — campo `role` na tabela `profile` com valores `member | moderator | admin` (espelhando roles do Discord)
 - [ ] **Geracao de IDs**: definir estrategia (`crypto.randomUUID()` vs `nanoid`)
 - [ ] **Rate limiting**: proteger endpoints de criacao contra abuso

--- a/src/docs/schema-banco-de-dados.md
+++ b/src/docs/schema-banco-de-dados.md
@@ -148,12 +148,24 @@ Perfil publico do usuario. Relacao 1:1 com `user`.
 | `linkedin` | `text("linkedin")` | — | URL do LinkedIn |
 | `interests` | `text("interests", { mode: "json" })` | — | Array JSON de areas de interesse |
 | `isOnboardingComplete` | `integer("is_onboarding_complete", { mode: "boolean" })` | NOT NULL, default `false` | Controle de fluxo do onboarding |
+| `role` | `text("role")` | NOT NULL, default `"member"` | Role na plataforma: `member` / `moderator` / `admin` |
 | `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
 | `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
+
+**Valores de `role`:**
+
+| Valor | Descricao |
+|-------|-----------|
+| `member` | Membro comum da comunidade (padrao para todos os usuarios) |
+| `moderator` | Moderador da comunidade — pode aprovar/rejeitar eventos e criar comunicados |
+| `admin` | Administrador da plataforma — todas as permissoes de moderator + gerenciamento geral |
+
+**Nota**: a role e atribuida manualmente no banco de dados ou via dashboard administrativo (futuro). Em uma versao futura, sera possivel sincronizar roles com as roles da comunidade no Discord via API.
 
 **Indices:**
 - `profile_userId_unique` em `userId` (UNIQUE)
 - `profile_username_unique` em `username` (UNIQUE)
+- `profile_role_idx` em `role`
 
 **Relations:**
 ```
@@ -233,13 +245,18 @@ Eventos da comunidade e parceiros.
 | `bannerUrl` | `text("banner_url")` | — | Banner/imagem do evento |
 | `organizerName` | `text("organizer_name")` | NOT NULL | Nome do organizador |
 | `isPartner` | `integer("is_partner", { mode: "boolean" })` | NOT NULL, default `false` | Se e parceiro externo (true) ou a propria comunidade (false) |
-| `createdBy` | `text("created_by")` | NOT NULL, FK → `user.id` CASCADE | Admin que cadastrou |
+| `status` | `text("status")` | NOT NULL, default `"pending"` | Status de aprovacao: `pending` / `approved` / `rejected` |
+| `rejectionReason` | `text("rejection_reason")` | — | Motivo da rejeicao, preenchido por moderator/admin |
+| `submittedBy` | `text("submitted_by")` | NOT NULL, FK → `user.id` CASCADE | Membro que submeteu o evento |
+| `reviewedBy` | `text("reviewed_by")` | FK → `user.id` SET NULL | Moderator/admin que revisou |
+| `reviewedAt` | `integer("reviewed_at", { mode: "timestamp_ms" })` | — | Data da revisao |
 | `createdAt` | `integer("created_at", { mode: "timestamp_ms" })` | NOT NULL, default now | |
 | `updatedAt` | `integer("updated_at", { mode: "timestamp_ms" })` | NOT NULL, default now, auto-update | |
 
 **Indices:**
 - `events_date_idx` em `date` (para ordenar proximos/passados)
-- `events_createdBy_idx` em `createdBy`
+- `events_status_idx` em `status` (para filtrar por status de aprovacao)
+- `events_submittedBy_idx` em `submittedBy`
 
 ---
 
@@ -268,7 +285,7 @@ user 1 ──→ N event_members
 
 ### `posts` (em `posts.schema.ts`)
 
-Posts do feed — comunicados de admin e atualizacoes de Build In Public.
+Posts do feed — comunicados de moderator/admin e atualizacoes de Build In Public.
 
 | Campo | Tipo Drizzle | Restricoes | Descricao |
 |-------|-------------|-----------|-----------|
@@ -435,7 +452,8 @@ projects 1 ──→ N comments
 | `user` | `profile` | 1:1 | `profile.userId` |
 | `user` | `project_members` | 1:N | `project_members.userId` |
 | `projects` | `project_members` | 1:N | `project_members.projectId` |
-| `user` | `events` | 1:N | `events.createdBy` |
+| `user` | `events` | 1:N | `events.submittedBy` |
+| `user` | `events` | 1:N | `events.reviewedBy` (moderator/admin que revisou) |
 | `events` | `event_members` | 1:N | `event_members.eventId` |
 | `user` | `event_members` | 1:N | `event_members.userId` |
 | `user` | `posts` | 1:N | `posts.authorId` |

--- a/src/lib/db/migrations/0003_add_profile_role.sql
+++ b/src/lib/db/migrations/0003_add_profile_role.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `profile` ADD `role` text DEFAULT 'member' NOT NULL;--> statement-breakpoint
+CREATE INDEX `profile_role_idx` ON `profile` (`role`);

--- a/src/lib/db/migrations/meta/0003_snapshot.json
+++ b/src/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,731 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0f4ec71f-01bb-45a0-be16-e763c966e335",
+  "prevId": "8883c483-340a-455a-b6a5-9a88d2d1ff6f",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "account_provider_account_unique": {
+          "name": "account_provider_account_unique",
+          "columns": [
+            "provider_id",
+            "account_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github": {
+          "name": "github",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "interests": {
+          "name": "interests",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_onboarding_complete": {
+          "name": "is_onboarding_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        }
+      },
+      "indexes": {
+        "profile_userId_unique": {
+          "name": "profile_userId_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "profile_username_unique": {
+          "name": "profile_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        },
+        "profile_role_idx": {
+          "name": "profile_role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": {
+          "name": "profile_user_id_user_id_fk",
+          "tableFrom": "profile",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'contributor'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_user_unique": {
+          "name": "project_members_project_user_unique",
+          "columns": [
+            "project_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "project_members_project_idx": {
+          "name": "project_members_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_members_user_idx": {
+          "name": "project_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_user_id_fk": {
+          "name": "project_members_user_id_user_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'outro'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ideia'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "projects_slug_unique": {
+          "name": "projects_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1773626520028,
       "tag": "0002_sweet_hardball",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1773897600000,
+      "tag": "0003_add_profile_role",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/profile.schema.ts
+++ b/src/lib/db/schema/profile.schema.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import {
+	index,
 	integer,
 	sqliteTable,
 	text,
@@ -29,6 +30,8 @@ export const profile = sqliteTable(
 			.notNull()
 			.default(false),
 
+		role: text("role").notNull().default("member"),
+
 		createdAt: integer("created_at", { mode: "timestamp_ms" })
 			.notNull()
 			.default(sql`(unixepoch() * 1000)`),
@@ -41,6 +44,7 @@ export const profile = sqliteTable(
 	(table) => [
 		uniqueIndex("profile_userId_unique").on(table.userId),
 		uniqueIndex("profile_username_unique").on(table.username),
+		index("profile_role_idx").on(table.role),
 	],
 );
 


### PR DESCRIPTION
## Summary

Documents two architectural decisions made after Phase 2:

1. **Role-based permission system**: Replace `isAdmin` boolean with `role` field (member/moderator/admin) in profile schema, mirroring Discord community roles.
2. **Event approval workflow**: Allow any authenticated member to submit events; moderators and admins review and approve before public listing.

These changes resolve the open "Sistema de admin" question and enable fine-grained permission control across events, announcements, and moderation. All 7 documentation files updated consistently with detailed routes, server functions, and schema definitions.