### PR TITLE
Implement Phase 3: Events feature with approval workflow

### DIFF
--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -1,0 +1,57 @@
+import { Link } from "@tanstack/react-router";
+import { Calendar } from "lucide-react";
+import { EventFormatBadge } from "@/components/event-format-badge";
+import { EventPartnerBadge } from "@/components/event-partner-badge";
+import { EventStatusBadge } from "@/components/event-status-badge";
+import type { EVENT_FORMATS, EVENT_STATUSES } from "@/lib/validations/event";
+import { formatEventDateShort } from "@/lib/utils";
+
+interface EventCardProps {
+	id: string;
+	name: string;
+	date: Date;
+	format: (typeof EVENT_FORMATS)[number];
+	organizerName: string;
+	isPartner: boolean;
+	status?: (typeof EVENT_STATUSES)[number];
+	showStatus?: boolean;
+}
+
+export function EventCard({
+	id,
+	name,
+	date,
+	format,
+	organizerName,
+	isPartner,
+	status,
+	showStatus = false,
+}: EventCardProps) {
+	return (
+		<Link
+			to="/events/$id"
+			params={{ id }}
+			className="group flex flex-col gap-3 rounded-lg border p-4 transition-colors hover:bg-muted/50"
+		>
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0 flex-1">
+					<h3 className="truncate font-medium group-hover:underline">
+						{name}
+					</h3>
+					<div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+						<Calendar className="size-3.5 shrink-0" />
+						<span>{formatEventDateShort(date)}</span>
+					</div>
+				</div>
+				{showStatus && status && <EventStatusBadge status={status} />}
+			</div>
+			<div className="flex flex-wrap items-center gap-2">
+				<EventFormatBadge format={format} />
+				<EventPartnerBadge isPartner={isPartner} />
+				<span className="text-xs text-muted-foreground">
+					por {organizerName}
+				</span>
+			</div>
+		</Link>
+	);
+}

--- a/src/components/event-form.tsx
+++ b/src/components/event-form.tsx
@@ -1,0 +1,298 @@
+import { useState } from "react";
+import { ImageUpload } from "@/components/image-upload";
+import { Button } from "@/components/ui/button";
+import {
+	Field,
+	FieldDescription,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+	FieldSeparator,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	type CreateEventInput,
+	EVENT_FORMATS,
+	EVENT_FORMAT_LABELS,
+	type UpdateEventInput,
+	createEventSchema,
+	updateEventSchema,
+} from "@/lib/validations/event";
+
+interface EventFormProps {
+	mode: "create" | "edit";
+	defaultValues?: Partial<CreateEventInput & { date: Date | string }>;
+	onSubmit: (data: CreateEventInput | UpdateEventInput) => Promise<void>;
+	isSubmitting: boolean;
+	canSetPartner?: boolean;
+}
+
+function toDatetimeLocalValue(date: Date | string | undefined): string {
+	if (!date) return "";
+	const d = date instanceof Date ? date : new Date(date);
+	if (Number.isNaN(d.getTime())) return "";
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function EventForm({
+	mode,
+	defaultValues,
+	onSubmit,
+	isSubmitting,
+	canSetPartner = false,
+}: EventFormProps) {
+	const [name, setName] = useState(defaultValues?.name ?? "");
+	const [description, setDescription] = useState(
+		defaultValues?.description ?? "",
+	);
+	const [dateStr, setDateStr] = useState(
+		toDatetimeLocalValue(defaultValues?.date),
+	);
+	const [format, setFormat] = useState<(typeof EVENT_FORMATS)[number]>(
+		(defaultValues?.format as (typeof EVENT_FORMATS)[number]) ?? "digital",
+	);
+	const [address, setAddress] = useState(defaultValues?.address ?? "");
+	const [accessLink, setAccessLink] = useState(
+		defaultValues?.accessLink ?? "",
+	);
+	const [eventLink, setEventLink] = useState(defaultValues?.eventLink ?? "");
+	const [bannerUrl, setBannerUrl] = useState(defaultValues?.bannerUrl ?? "");
+	const [organizerName, setOrganizerName] = useState(
+		defaultValues?.organizerName ?? "",
+	);
+	const [isPartner, setIsPartner] = useState(
+		defaultValues?.isPartner ?? false,
+	);
+	const [errors, setErrors] = useState<Record<string, string>>({});
+
+	const handleSubmit = async () => {
+		const formData = {
+			name,
+			description: description || null,
+			date: dateStr ? new Date(dateStr) : undefined,
+			format,
+			address: format === "presencial" ? address || null : null,
+			accessLink: format === "digital" ? accessLink || null : null,
+			eventLink,
+			bannerUrl: bannerUrl || null,
+			organizerName,
+			isPartner,
+		};
+
+		const schema =
+			mode === "create" ? createEventSchema : updateEventSchema;
+		const result = schema.safeParse(formData);
+
+		if (!result.success) {
+			const fieldErrors: Record<string, string> = {};
+			for (const issue of result.error.issues) {
+				const field = issue.path[0];
+				if (field) {
+					fieldErrors[String(field)] = issue.message;
+				}
+			}
+			setErrors(fieldErrors);
+			return;
+		}
+
+		setErrors({});
+		await onSubmit(result.data);
+	};
+
+	return (
+		<FieldGroup>
+			<Field>
+				<FieldLabel>Banner do evento</FieldLabel>
+				<FieldDescription>
+					Imagem do evento, maximo 2MB (JPEG, PNG, WebP ou SVG)
+				</FieldDescription>
+				<ImageUpload
+					value={bannerUrl || null}
+					onChange={(val) => setBannerUrl(val ?? "")}
+					category="event-banners"
+					fallback={name || "E"}
+				/>
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel htmlFor="name">Nome do evento *</FieldLabel>
+				<Input
+					id="name"
+					placeholder="Nome do evento"
+					value={name}
+					onChange={(e) => setName(e.target.value)}
+					maxLength={200}
+				/>
+				{errors.name && <FieldError>{errors.name}</FieldError>}
+			</Field>
+
+			<Field>
+				<FieldLabel htmlFor="description">Descricao</FieldLabel>
+				<FieldDescription>
+					Descreva o evento (max. 1000 caracteres)
+				</FieldDescription>
+				<Textarea
+					id="description"
+					placeholder="Detalhes sobre o evento..."
+					value={description}
+					onChange={(e) => setDescription(e.target.value)}
+					maxLength={1000}
+					rows={4}
+				/>
+				{errors.description && (
+					<FieldError>{errors.description}</FieldError>
+				)}
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel htmlFor="date">Data e horario *</FieldLabel>
+				<Input
+					id="date"
+					type="datetime-local"
+					value={dateStr}
+					onChange={(e) => setDateStr(e.target.value)}
+				/>
+				{errors.date && <FieldError>{errors.date}</FieldError>}
+			</Field>
+
+			<Field>
+				<FieldLabel>Formato *</FieldLabel>
+				<Select
+					value={format}
+					onValueChange={(val) =>
+						setFormat(val as (typeof EVENT_FORMATS)[number])
+					}
+				>
+					<SelectTrigger>
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{EVENT_FORMATS.map((f) => (
+							<SelectItem key={f} value={f}>
+								{EVENT_FORMAT_LABELS[f]}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				{errors.format && <FieldError>{errors.format}</FieldError>}
+			</Field>
+
+			{format === "presencial" && (
+				<Field>
+					<FieldLabel htmlFor="address">Endereco *</FieldLabel>
+					<FieldDescription>
+						Endereco completo do local do evento
+					</FieldDescription>
+					<Input
+						id="address"
+						placeholder="Rua, numero, cidade..."
+						value={address}
+						onChange={(e) => setAddress(e.target.value)}
+					/>
+					{errors.address && <FieldError>{errors.address}</FieldError>}
+				</Field>
+			)}
+
+			{format === "digital" && (
+				<Field>
+					<FieldLabel htmlFor="accessLink">Link de acesso *</FieldLabel>
+					<FieldDescription>
+						Link para acessar o evento online (Discord, Zoom, YouTube, etc.)
+					</FieldDescription>
+					<Input
+						id="accessLink"
+						type="url"
+						placeholder="https://discord.gg/..."
+						value={accessLink}
+						onChange={(e) => setAccessLink(e.target.value)}
+					/>
+					{errors.accessLink && (
+						<FieldError>{errors.accessLink}</FieldError>
+					)}
+				</Field>
+			)}
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel htmlFor="eventLink">Pagina oficial do evento *</FieldLabel>
+				<FieldDescription>
+					Link para a pagina oficial com mais informacoes
+				</FieldDescription>
+				<Input
+					id="eventLink"
+					type="url"
+					placeholder="https://..."
+					value={eventLink}
+					onChange={(e) => setEventLink(e.target.value)}
+				/>
+				{errors.eventLink && <FieldError>{errors.eventLink}</FieldError>}
+			</Field>
+
+			<FieldSeparator />
+
+			<Field>
+				<FieldLabel htmlFor="organizerName">
+					Nome do organizador *
+				</FieldLabel>
+				<Input
+					id="organizerName"
+					placeholder="Nome da pessoa ou organizacao"
+					value={organizerName}
+					onChange={(e) => setOrganizerName(e.target.value)}
+					maxLength={100}
+				/>
+				{errors.organizerName && (
+					<FieldError>{errors.organizerName}</FieldError>
+				)}
+			</Field>
+
+			{canSetPartner && (
+				<Field>
+					<div className="flex items-center gap-3">
+						<Switch
+							id="isPartner"
+							checked={isPartner}
+							onCheckedChange={setIsPartner}
+						/>
+						<FieldLabel htmlFor="isPartner" className="mb-0">
+							Evento de parceiro externo
+						</FieldLabel>
+					</div>
+					<FieldDescription>
+						Marque se o evento e organizado por um parceiro externo, nao pela
+						comunidade
+					</FieldDescription>
+				</Field>
+			)}
+
+			<Button
+				type="button"
+				className="w-full"
+				size="lg"
+				disabled={isSubmitting}
+				onClick={handleSubmit}
+			>
+				{isSubmitting
+					? "Salvando..."
+					: mode === "create"
+						? "Submeter evento"
+						: "Salvar alteracoes"}
+			</Button>
+		</FieldGroup>
+	);
+}

--- a/src/components/event-format-badge.tsx
+++ b/src/components/event-format-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@/components/ui/badge";
+import {
+	EVENT_FORMAT_COLORS,
+	EVENT_FORMAT_LABELS,
+	type EVENT_FORMATS,
+} from "@/lib/validations/event";
+import { cn } from "@/lib/utils";
+
+interface EventFormatBadgeProps {
+	format: (typeof EVENT_FORMATS)[number];
+	className?: string;
+}
+
+export function EventFormatBadge({
+	format,
+	className,
+}: EventFormatBadgeProps) {
+	return (
+		<Badge
+			variant="outline"
+			className={cn(EVENT_FORMAT_COLORS[format] ?? "", className)}
+		>
+			{EVENT_FORMAT_LABELS[format] ?? format}
+		</Badge>
+	);
+}

--- a/src/components/event-partner-badge.tsx
+++ b/src/components/event-partner-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface EventPartnerBadgeProps {
+	isPartner: boolean;
+	className?: string;
+}
+
+export function EventPartnerBadge({
+	isPartner,
+	className,
+}: EventPartnerBadgeProps) {
+	return (
+		<Badge
+			variant="outline"
+			className={cn(
+				isPartner
+					? "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400"
+					: "bg-teal-100 text-teal-800 dark:bg-teal-900/30 dark:text-teal-400",
+				className,
+			)}
+		>
+			{isPartner ? "Parceiro" : "Comunidade"}
+		</Badge>
+	);
+}

--- a/src/components/event-rejection-notice.tsx
+++ b/src/components/event-rejection-notice.tsx
@@ -1,0 +1,32 @@
+import { Link } from "@tanstack/react-router";
+import { AlertCircle, Pencil } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+interface EventRejectionNoticeProps {
+	rejectionReason: string | null;
+	eventId: string;
+}
+
+export function EventRejectionNotice({
+	rejectionReason,
+	eventId,
+}: EventRejectionNoticeProps) {
+	return (
+		<Alert variant="destructive">
+			<AlertCircle className="size-4" />
+			<AlertTitle>Evento rejeitado</AlertTitle>
+			<AlertDescription className="mt-2">
+				<p>
+					{rejectionReason || "Nenhum motivo informado pelo moderador."}
+				</p>
+				<Button asChild size="sm" variant="outline" className="mt-3">
+					<Link to="/events/$id/editar" params={{ id: eventId }}>
+						<Pencil className="size-3.5" />
+						Editar e resubmeter
+					</Link>
+				</Button>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/src/components/event-review-panel.tsx
+++ b/src/components/event-review-panel.tsx
@@ -1,0 +1,91 @@
+import { Check, X } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface EventReviewPanelProps {
+	onApprove: () => Promise<void>;
+	onReject: (reason?: string) => Promise<void>;
+}
+
+export function EventReviewPanel({
+	onApprove,
+	onReject,
+}: EventReviewPanelProps) {
+	const [showRejectForm, setShowRejectForm] = useState(false);
+	const [reason, setReason] = useState("");
+	const [isApproving, setIsApproving] = useState(false);
+	const [isRejecting, setIsRejecting] = useState(false);
+
+	const handleApprove = async () => {
+		setIsApproving(true);
+		try {
+			await onApprove();
+		} finally {
+			setIsApproving(false);
+		}
+	};
+
+	const handleReject = async () => {
+		setIsRejecting(true);
+		try {
+			await onReject(reason || undefined);
+		} finally {
+			setIsRejecting(false);
+		}
+	};
+
+	return (
+		<div className="rounded-lg border bg-muted/50 p-6">
+			<h3 className="mb-4 font-semibold">Revisao do evento</h3>
+
+			{!showRejectForm ? (
+				<div className="flex gap-3">
+					<Button
+						onClick={handleApprove}
+						disabled={isApproving}
+						className="bg-green-600 hover:bg-green-700"
+					>
+						<Check className="size-4" />
+						{isApproving ? "Aprovando..." : "Aprovar"}
+					</Button>
+					<Button
+						variant="destructive"
+						onClick={() => setShowRejectForm(true)}
+					>
+						<X className="size-4" />
+						Rejeitar
+					</Button>
+				</div>
+			) : (
+				<div className="space-y-3">
+					<Textarea
+						placeholder="Motivo da rejeicao (opcional)"
+						value={reason}
+						onChange={(e) => setReason(e.target.value)}
+						maxLength={500}
+						rows={3}
+					/>
+					<div className="flex gap-3">
+						<Button
+							variant="destructive"
+							onClick={handleReject}
+							disabled={isRejecting}
+						>
+							{isRejecting ? "Rejeitando..." : "Confirmar rejeicao"}
+						</Button>
+						<Button
+							variant="outline"
+							onClick={() => {
+								setShowRejectForm(false);
+								setReason("");
+							}}
+						>
+							Cancelar
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/event-status-badge.tsx
+++ b/src/components/event-status-badge.tsx
@@ -1,0 +1,26 @@
+import { Badge } from "@/components/ui/badge";
+import {
+	EVENT_STATUS_COLORS,
+	EVENT_STATUS_LABELS,
+	type EVENT_STATUSES,
+} from "@/lib/validations/event";
+import { cn } from "@/lib/utils";
+
+interface EventStatusBadgeProps {
+	status: (typeof EVENT_STATUSES)[number];
+	className?: string;
+}
+
+export function EventStatusBadge({
+	status,
+	className,
+}: EventStatusBadgeProps) {
+	return (
+		<Badge
+			variant="secondary"
+			className={cn(EVENT_STATUS_COLORS[status] ?? "", className)}
+		>
+			{EVENT_STATUS_LABELS[status] ?? status}
+		</Badge>
+	);
+}

--- a/src/data/services/event.ts
+++ b/src/data/services/event.ts
@@ -1,0 +1,330 @@
+import { createServerFn } from "@tanstack/react-start";
+import { and, eq, gt, lte, or, sql } from "drizzle-orm";
+import { ensureSession, getSession } from "@/lib/auth/server";
+import { getDb } from "@/lib/db";
+import { events, profile } from "@/lib/db/schema";
+import {
+	type CreateEventInput,
+	type UpdateEventInput,
+	createEventSchema,
+	updateEventSchema,
+} from "@/lib/validations/event";
+
+async function getUserRole(
+	db: ReturnType<typeof getDb>,
+	userId: string,
+): Promise<string> {
+	const p = await db.query.profile.findFirst({
+		where: eq(profile.userId, userId),
+		columns: { role: true },
+	});
+	return p?.role ?? "member";
+}
+
+function isMod(role: string): boolean {
+	return role === "moderator" || role === "admin";
+}
+
+export const createEvent = createServerFn({ method: "POST" }).handler(
+	async ({ data }: { data: CreateEventInput }) => {
+		const parsed = createEventSchema.parse(data);
+		const session = await ensureSession();
+		const db = getDb();
+
+		const userProfile = await db.query.profile.findFirst({
+			where: eq(profile.userId, session.user.id),
+			columns: { isOnboardingComplete: true },
+		});
+
+		if (!userProfile?.isOnboardingComplete) {
+			throw new Error("Perfil incompleto");
+		}
+
+		const id = crypto.randomUUID();
+		await db.insert(events).values({
+			id,
+			name: parsed.name,
+			description: parsed.description ?? null,
+			date: parsed.date,
+			format: parsed.format,
+			address: parsed.address ?? null,
+			accessLink: parsed.accessLink ?? null,
+			eventLink: parsed.eventLink,
+			bannerUrl: parsed.bannerUrl ?? null,
+			organizerName: parsed.organizerName,
+			isPartner: parsed.isPartner,
+			status: "pending",
+			submittedBy: session.user.id,
+		});
+
+		return { id };
+	},
+);
+
+export const updateEvent = createServerFn({ method: "POST" }).handler(
+	async ({
+		data,
+	}: { data: { eventId: string; updates: UpdateEventInput } }) => {
+		const parsed = updateEventSchema.parse(data.updates);
+		const session = await ensureSession();
+		const db = getDb();
+
+		const event = await db.query.events.findFirst({
+			where: eq(events.id, data.eventId),
+		});
+
+		if (!event) {
+			throw new Error("Evento nao encontrado");
+		}
+
+		const role = await getUserRole(db, session.user.id);
+		const isAuthor = event.submittedBy === session.user.id;
+
+		if (!isMod(role) && !(isAuthor && event.status === "rejected")) {
+			throw new Error("Sem permissao para editar este evento");
+		}
+
+		const updateData: Record<string, unknown> = {
+			name: parsed.name,
+			description: parsed.description ?? null,
+			date: parsed.date,
+			format: parsed.format,
+			address: parsed.address ?? null,
+			accessLink: parsed.accessLink ?? null,
+			eventLink: parsed.eventLink,
+			bannerUrl: parsed.bannerUrl ?? null,
+			organizerName: parsed.organizerName,
+			isPartner: parsed.isPartner,
+		};
+
+		if (isAuthor && event.status === "rejected") {
+			updateData.status = "pending";
+			updateData.rejectionReason = null;
+			updateData.reviewedBy = null;
+			updateData.reviewedAt = null;
+		}
+
+		await db
+			.update(events)
+			.set(updateData)
+			.where(eq(events.id, data.eventId));
+
+		return { success: true };
+	},
+);
+
+export const deleteEvent = createServerFn({ method: "POST" }).handler(
+	async ({ data: eventId }: { data: string }) => {
+		const session = await ensureSession();
+		const db = getDb();
+
+		const role = await getUserRole(db, session.user.id);
+		if (!isMod(role)) {
+			throw new Error("Apenas moderadores e admins podem excluir eventos");
+		}
+
+		await db.delete(events).where(eq(events.id, eventId));
+
+		return { success: true };
+	},
+);
+
+export const approveEvent = createServerFn({ method: "POST" }).handler(
+	async ({ data: eventId }: { data: string }) => {
+		const session = await ensureSession();
+		const db = getDb();
+
+		const role = await getUserRole(db, session.user.id);
+		if (!isMod(role)) {
+			throw new Error("Apenas moderadores e admins podem aprovar eventos");
+		}
+
+		const event = await db.query.events.findFirst({
+			where: eq(events.id, eventId),
+		});
+
+		if (!event) {
+			throw new Error("Evento nao encontrado");
+		}
+
+		if (event.status !== "pending") {
+			throw new Error("Apenas eventos pendentes podem ser aprovados");
+		}
+
+		await db
+			.update(events)
+			.set({
+				status: "approved",
+				reviewedBy: session.user.id,
+				reviewedAt: new Date(),
+			})
+			.where(eq(events.id, eventId));
+
+		return { success: true };
+	},
+);
+
+export const rejectEvent = createServerFn({ method: "POST" }).handler(
+	async ({
+		data,
+	}: { data: { eventId: string; reason?: string } }) => {
+		const session = await ensureSession();
+		const db = getDb();
+
+		const role = await getUserRole(db, session.user.id);
+		if (!isMod(role)) {
+			throw new Error("Apenas moderadores e admins podem rejeitar eventos");
+		}
+
+		const event = await db.query.events.findFirst({
+			where: eq(events.id, data.eventId),
+		});
+
+		if (!event) {
+			throw new Error("Evento nao encontrado");
+		}
+
+		if (event.status !== "pending") {
+			throw new Error("Apenas eventos pendentes podem ser rejeitados");
+		}
+
+		await db
+			.update(events)
+			.set({
+				status: "rejected",
+				rejectionReason: data.reason ?? null,
+				reviewedBy: session.user.id,
+				reviewedAt: new Date(),
+			})
+			.where(eq(events.id, data.eventId));
+
+		return { success: true };
+	},
+);
+
+export const resubmitEvent = createServerFn({ method: "POST" }).handler(
+	async ({ data: eventId }: { data: string }) => {
+		const session = await ensureSession();
+		const db = getDb();
+
+		const event = await db.query.events.findFirst({
+			where: eq(events.id, eventId),
+		});
+
+		if (!event) {
+			throw new Error("Evento nao encontrado");
+		}
+
+		if (event.submittedBy !== session.user.id) {
+			throw new Error("Apenas o autor pode resubmeter o evento");
+		}
+
+		if (event.status !== "rejected") {
+			throw new Error("Apenas eventos rejeitados podem ser resubmetidos");
+		}
+
+		await db
+			.update(events)
+			.set({
+				status: "pending",
+				rejectionReason: null,
+				reviewedBy: null,
+				reviewedAt: null,
+			})
+			.where(eq(events.id, eventId));
+
+		return { success: true };
+	},
+);
+
+export const getEventById = createServerFn({ method: "GET" }).handler(
+	async ({ data: eventId }: { data: string }) => {
+		const session = await getSession();
+		const db = getDb();
+
+		const event = await db.query.events.findFirst({
+			where: eq(events.id, eventId),
+		});
+
+		if (!event) return null;
+
+		if (event.status !== "approved") {
+			if (!session) return null;
+
+			const isAuthor = event.submittedBy === session.user.id;
+			const role = await getUserRole(db, session.user.id);
+
+			if (!isAuthor && !isMod(role)) return null;
+		}
+
+		const submitterProfile = await db.query.profile.findFirst({
+			where: eq(profile.userId, event.submittedBy),
+			columns: {
+				username: true,
+				displayName: true,
+				avatarUrl: true,
+			},
+		});
+
+		return {
+			...event,
+			submitterProfile: submitterProfile ?? null,
+		};
+	},
+);
+
+export const listEvents = createServerFn({ method: "GET" }).handler(
+	async () => {
+		const session = await getSession();
+		const db = getDb();
+
+		let requesterRole = "visitor";
+		const userId = session?.user?.id;
+
+		if (userId) {
+			requesterRole = await getUserRole(db, userId);
+		}
+
+		const now = new Date();
+
+		let allEvents: (typeof events.$inferSelect)[];
+
+		if (isMod(requesterRole)) {
+			allEvents = await db.query.events.findMany({
+				orderBy: (events, { asc, desc }) => [desc(events.createdAt)],
+			});
+		} else if (userId) {
+			allEvents = await db.query.events.findMany({
+				where: or(
+					eq(events.status, "approved"),
+					eq(events.submittedBy, userId),
+				),
+				orderBy: (events, { desc }) => [desc(events.createdAt)],
+			});
+		} else {
+			allEvents = await db.query.events.findMany({
+				where: eq(events.status, "approved"),
+				orderBy: (events, { desc }) => [desc(events.createdAt)],
+			});
+		}
+
+		const pending = allEvents
+			.filter((e) => e.status === "pending")
+			.sort(
+				(a, b) =>
+					(a.createdAt?.getTime() ?? 0) - (b.createdAt?.getTime() ?? 0),
+			);
+
+		const upcoming = allEvents
+			.filter((e) => e.status === "approved" && e.date > now)
+			.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+		const past = allEvents
+			.filter((e) => e.status === "approved" && e.date <= now)
+			.sort((a, b) => b.date.getTime() - a.date.getTime());
+
+		const rejected = allEvents.filter((e) => e.status === "rejected");
+
+		return { pending, upcoming, past, rejected, requesterRole };
+	},
+);

--- a/src/lib/db/migrations/0004_add_events.sql
+++ b/src/lib/db/migrations/0004_add_events.sql
@@ -1,0 +1,37 @@
+CREATE TABLE `events` (
+	`id` text PRIMARY KEY NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`date` integer NOT NULL,
+	`format` text NOT NULL,
+	`address` text,
+	`access_link` text,
+	`event_link` text NOT NULL,
+	`banner_url` text,
+	`organizer_name` text NOT NULL,
+	`is_partner` integer DEFAULT false NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`rejection_reason` text,
+	`submitted_by` text NOT NULL,
+	`reviewed_by` text,
+	`reviewed_at` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`submitted_by`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`reviewed_by`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `events_date_idx` ON `events` (`date`);--> statement-breakpoint
+CREATE INDEX `events_status_idx` ON `events` (`status`);--> statement-breakpoint
+CREATE INDEX `events_submittedBy_idx` ON `events` (`submitted_by`);--> statement-breakpoint
+CREATE TABLE `event_members` (
+	`id` text PRIMARY KEY NOT NULL,
+	`event_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`status` text DEFAULT 'interessado' NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `event_members_event_user_unique` ON `event_members` (`event_id`,`user_id`);

--- a/src/lib/db/migrations/meta/0004_snapshot.json
+++ b/src/lib/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,237 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "0f4ec71f-01bb-45a0-be16-e763c966e335",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "account_id": { "name": "account_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "provider_id": { "name": "provider_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "user_id": { "name": "user_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "access_token": { "name": "access_token", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "refresh_token": { "name": "refresh_token", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "id_token": { "name": "id_token", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "access_token_expires_at": { "name": "access_token_expires_at", "type": "integer", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "refresh_token_expires_at": { "name": "refresh_token_expires_at", "type": "integer", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "scope": { "name": "scope", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "password": { "name": "password", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "account_userId_idx": { "name": "account_userId_idx", "columns": ["user_id"], "isUnique": false },
+        "account_provider_account_unique": { "name": "account_provider_account_unique", "columns": ["provider_id", "account_id"], "isUnique": true }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": { "name": "account_user_id_user_id_fk", "tableFrom": "account", "tableTo": "user", "columnsFrom": ["user_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "expires_at": { "name": "expires_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "token": { "name": "token", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "ip_address": { "name": "ip_address", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "user_agent": { "name": "user_agent", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "user_id": { "name": "user_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false }
+      },
+      "indexes": {
+        "session_userId_idx": { "name": "session_userId_idx", "columns": ["user_id"], "isUnique": false },
+        "session_token_unique": { "name": "session_token_unique", "columns": ["token"], "isUnique": true }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": { "name": "session_user_id_user_id_fk", "tableFrom": "session", "tableTo": "user", "columnsFrom": ["user_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "name": { "name": "name", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "email": { "name": "email", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "email_verified": { "name": "email_verified", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": false },
+        "image": { "name": "image", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "user_email_unique": { "name": "user_email_unique", "columns": ["email"], "isUnique": true }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "identifier": { "name": "identifier", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "value": { "name": "value", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "expires_at": { "name": "expires_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "verification_identifier_idx": { "name": "verification_identifier_idx", "columns": ["identifier"], "isUnique": false }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile": {
+      "name": "profile",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "user_id": { "name": "user_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "username": { "name": "username", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "display_name": { "name": "display_name", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "bio": { "name": "bio", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "avatar_url": { "name": "avatar_url", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "website": { "name": "website", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "github": { "name": "github", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "twitter": { "name": "twitter", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "linkedin": { "name": "linkedin", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "interests": { "name": "interests", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "is_onboarding_complete": { "name": "is_onboarding_complete", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "role": { "name": "role", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'member'" }
+      },
+      "indexes": {
+        "profile_userId_unique": { "name": "profile_userId_unique", "columns": ["user_id"], "isUnique": true },
+        "profile_username_unique": { "name": "profile_username_unique", "columns": ["username"], "isUnique": true },
+        "profile_role_idx": { "name": "profile_role_idx", "columns": ["role"], "isUnique": false }
+      },
+      "foreignKeys": {
+        "profile_user_id_user_id_fk": { "name": "profile_user_id_user_id_fk", "tableFrom": "profile", "tableTo": "user", "columnsFrom": ["user_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "project_id": { "name": "project_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "user_id": { "name": "user_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "role": { "name": "role", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'contributor'" },
+        "joined_at": { "name": "joined_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "project_members_project_user_unique": { "name": "project_members_project_user_unique", "columns": ["project_id", "user_id"], "isUnique": true },
+        "project_members_project_idx": { "name": "project_members_project_idx", "columns": ["project_id"], "isUnique": false },
+        "project_members_user_idx": { "name": "project_members_user_idx", "columns": ["user_id"], "isUnique": false }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": { "name": "project_members_project_id_projects_id_fk", "tableFrom": "project_members", "tableTo": "projects", "columnsFrom": ["project_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" },
+        "project_members_user_id_user_id_fk": { "name": "project_members_user_id_user_id_fk", "tableFrom": "project_members", "tableTo": "user", "columnsFrom": ["user_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "name": { "name": "name", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "slug": { "name": "slug", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "description": { "name": "description", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "url": { "name": "url", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "logo_url": { "name": "logo_url", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "category": { "name": "category", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'outro'" },
+        "status": { "name": "status", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'ideia'" },
+        "tags": { "name": "tags", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "projects_slug_unique": { "name": "projects_slug_unique", "columns": ["slug"], "isUnique": true }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "name": { "name": "name", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "description": { "name": "description", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "date": { "name": "date", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "format": { "name": "format", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "address": { "name": "address", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "access_link": { "name": "access_link", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "event_link": { "name": "event_link", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "banner_url": { "name": "banner_url", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "organizer_name": { "name": "organizer_name", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "is_partner": { "name": "is_partner", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": false },
+        "status": { "name": "status", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'pending'" },
+        "rejection_reason": { "name": "rejection_reason", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "submitted_by": { "name": "submitted_by", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "reviewed_by": { "name": "reviewed_by", "type": "text", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "reviewed_at": { "name": "reviewed_at", "type": "integer", "primaryKey": false, "notNull": false, "autoincrement": false },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" },
+        "updated_at": { "name": "updated_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "events_date_idx": { "name": "events_date_idx", "columns": ["date"], "isUnique": false },
+        "events_status_idx": { "name": "events_status_idx", "columns": ["status"], "isUnique": false },
+        "events_submittedBy_idx": { "name": "events_submittedBy_idx", "columns": ["submitted_by"], "isUnique": false }
+      },
+      "foreignKeys": {
+        "events_submitted_by_user_id_fk": { "name": "events_submitted_by_user_id_fk", "tableFrom": "events", "tableTo": "user", "columnsFrom": ["submitted_by"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" },
+        "events_reviewed_by_user_id_fk": { "name": "events_reviewed_by_user_id_fk", "tableFrom": "events", "tableTo": "user", "columnsFrom": ["reviewed_by"], "columnsTo": ["id"], "onDelete": "set null", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_members": {
+      "name": "event_members",
+      "columns": {
+        "id": { "name": "id", "type": "text", "primaryKey": true, "notNull": true, "autoincrement": false },
+        "event_id": { "name": "event_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "user_id": { "name": "user_id", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false },
+        "status": { "name": "status", "type": "text", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "'interessado'" },
+        "created_at": { "name": "created_at", "type": "integer", "primaryKey": false, "notNull": true, "autoincrement": false, "default": "(unixepoch() * 1000)" }
+      },
+      "indexes": {
+        "event_members_event_user_unique": { "name": "event_members_event_user_unique", "columns": ["event_id", "user_id"], "isUnique": true }
+      },
+      "foreignKeys": {
+        "event_members_event_id_events_id_fk": { "name": "event_members_event_id_events_id_fk", "tableFrom": "event_members", "tableTo": "events", "columnsFrom": ["event_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" },
+        "event_members_user_id_user_id_fk": { "name": "event_members_user_id_user_id_fk", "tableFrom": "event_members", "tableTo": "user", "columnsFrom": ["user_id"], "columnsTo": ["id"], "onDelete": "cascade", "onUpdate": "no action" }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1773897600000,
       "tag": "0003_add_profile_role",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1773984000000,
+      "tag": "0004_add_events",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/events.schema.ts
+++ b/src/lib/db/schema/events.schema.ts
@@ -1,0 +1,99 @@
+import { relations, sql } from "drizzle-orm";
+import {
+	index,
+	integer,
+	sqliteTable,
+	text,
+	uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { user } from "./auth.schema";
+
+export const events = sqliteTable(
+	"events",
+	{
+		id: text("id").primaryKey(),
+		name: text("name").notNull(),
+		description: text("description"),
+		date: integer("date", { mode: "timestamp_ms" }).notNull(),
+		format: text("format").notNull(),
+		address: text("address"),
+		accessLink: text("access_link"),
+		eventLink: text("event_link").notNull(),
+		bannerUrl: text("banner_url"),
+		organizerName: text("organizer_name").notNull(),
+		isPartner: integer("is_partner", { mode: "boolean" })
+			.notNull()
+			.default(false),
+		status: text("status").notNull().default("pending"),
+		rejectionReason: text("rejection_reason"),
+		submittedBy: text("submitted_by")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		reviewedBy: text("reviewed_by").references(() => user.id, {
+			onDelete: "set null",
+		}),
+		reviewedAt: integer("reviewed_at", { mode: "timestamp_ms" }),
+
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`),
+		updatedAt: integer("updated_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`)
+			.$onUpdate(() => new Date()),
+	},
+	(table) => [
+		index("events_date_idx").on(table.date),
+		index("events_status_idx").on(table.status),
+		index("events_submittedBy_idx").on(table.submittedBy),
+	],
+);
+
+export const eventMembers = sqliteTable(
+	"event_members",
+	{
+		id: text("id").primaryKey(),
+		eventId: text("event_id")
+			.notNull()
+			.references(() => events.id, { onDelete: "cascade" }),
+		userId: text("user_id")
+			.notNull()
+			.references(() => user.id, { onDelete: "cascade" }),
+		status: text("status").notNull().default("interessado"),
+
+		createdAt: integer("created_at", { mode: "timestamp_ms" })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`),
+	},
+	(table) => [
+		uniqueIndex("event_members_event_user_unique").on(
+			table.eventId,
+			table.userId,
+		),
+	],
+);
+
+export const eventsRelations = relations(events, ({ one, many }) => ({
+	submitter: one(user, {
+		fields: [events.submittedBy],
+		references: [user.id],
+		relationName: "eventSubmitter",
+	}),
+	reviewer: one(user, {
+		fields: [events.reviewedBy],
+		references: [user.id],
+		relationName: "eventReviewer",
+	}),
+	members: many(eventMembers),
+}));
+
+export const eventMembersRelations = relations(eventMembers, ({ one }) => ({
+	event: one(events, {
+		fields: [eventMembers.eventId],
+		references: [events.id],
+	}),
+	user: one(user, {
+		fields: [eventMembers.userId],
+		references: [user.id],
+	}),
+}));

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -1,3 +1,4 @@
 export * from "./auth.schema";
 export * from "./profile.schema";
 export * from "./projects.schema";
+export * from "./events.schema";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,3 +15,24 @@ export function generateSlug(name: string): string {
     .replace(/-{2,}/g, "-")
     .replace(/^-|-$/g, "");
 }
+
+export function formatEventDateShort(date: Date): string {
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export function formatEventDateLong(date: Date): string {
+  return new Intl.DateTimeFormat("pt-BR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}

--- a/src/lib/validations/event.ts
+++ b/src/lib/validations/event.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+export const EVENT_FORMATS = ["presencial", "digital"] as const;
+
+export const EVENT_FORMAT_LABELS: Record<
+	(typeof EVENT_FORMATS)[number],
+	string
+> = {
+	presencial: "Presencial",
+	digital: "Digital",
+};
+
+export const EVENT_FORMAT_COLORS: Record<
+	(typeof EVENT_FORMATS)[number],
+	string
+> = {
+	presencial:
+		"bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+	digital:
+		"bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+};
+
+export const EVENT_STATUSES = ["pending", "approved", "rejected"] as const;
+
+export const EVENT_STATUS_LABELS: Record<
+	(typeof EVENT_STATUSES)[number],
+	string
+> = {
+	pending: "Pendente",
+	approved: "Aprovado",
+	rejected: "Rejeitado",
+};
+
+export const EVENT_STATUS_COLORS: Record<
+	(typeof EVENT_STATUSES)[number],
+	string
+> = {
+	pending:
+		"bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+	approved:
+		"bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+	rejected:
+		"bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+};
+
+const baseEventSchema = z
+	.object({
+		name: z
+			.string()
+			.min(2, "Nome deve ter pelo menos 2 caracteres")
+			.max(200, "Nome deve ter no maximo 200 caracteres"),
+		description: z
+			.string()
+			.max(1000, "Descricao deve ter no maximo 1000 caracteres")
+			.nullable()
+			.optional(),
+		date: z.coerce.date({ message: "Data invalida" }),
+		format: z.enum(EVENT_FORMATS, {
+			error: "Formato invalido",
+		}),
+		address: z.string().nullable().optional(),
+		accessLink: z
+			.string()
+			.url("URL de acesso invalida")
+			.nullable()
+			.optional()
+			.or(z.literal("").transform(() => null)),
+		eventLink: z.string().url("URL da pagina oficial invalida"),
+		bannerUrl: z
+			.string()
+			.url("URL do banner invalida")
+			.nullable()
+			.optional()
+			.or(z.literal("").transform(() => null)),
+		organizerName: z
+			.string()
+			.min(2, "Nome do organizador deve ter pelo menos 2 caracteres")
+			.max(100, "Nome do organizador deve ter no maximo 100 caracteres"),
+		isPartner: z.boolean().default(false),
+	})
+	.superRefine((data, ctx) => {
+		if (data.format === "presencial" && (!data.address || data.address.trim() === "")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Endereco e obrigatorio para eventos presenciais",
+				path: ["address"],
+			});
+		}
+		if (data.format === "digital" && (!data.accessLink || data.accessLink.trim() === "")) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Link de acesso e obrigatorio para eventos digitais",
+				path: ["accessLink"],
+			});
+		}
+	});
+
+export const createEventSchema = baseEventSchema.refine(
+	(data) => data.date > new Date(),
+	{
+		message: "Data deve ser no futuro",
+		path: ["date"],
+	},
+);
+
+export const updateEventSchema = baseEventSchema;
+
+export const rejectEventSchema = z.object({
+	reason: z
+		.string()
+		.max(500, "Motivo deve ter no maximo 500 caracteres")
+		.nullable()
+		.optional(),
+});
+
+export type CreateEventInput = z.infer<typeof createEventSchema>;
+export type UpdateEventInput = z.infer<typeof updateEventSchema>;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,13 +12,18 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as PageRouteImport } from './routes/page'
 import { Route as ProjectsPageRouteImport } from './routes/projects/page'
 import { Route as OnboardingPageRouteImport } from './routes/onboarding/page'
+import { Route as EventsPageRouteImport } from './routes/events/page'
 import { Route as ConfiguracoesPageRouteImport } from './routes/configuracoes/page'
 import { Route as UUsernamePageRouteImport } from './routes/u/$username/page'
 import { Route as ProjectsNovoPageRouteImport } from './routes/projects/novo/page'
 import { Route as ProjectsSlugPageRouteImport } from './routes/projects/$slug/page'
+import { Route as EventsNovoPageRouteImport } from './routes/events/novo/page'
+import { Route as EventsIdPageRouteImport } from './routes/events/$id/page'
 import { Route as ApiUploadsSplatRouteImport } from './routes/api/uploads/$'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ProjectsSlugEditarPageRouteImport } from './routes/projects/$slug/editar/page'
+import { Route as EventsIdRevisaoPageRouteImport } from './routes/events/$id/revisao/page'
+import { Route as EventsIdEditarPageRouteImport } from './routes/events/$id/editar/page'
 
 const PageRoute = PageRouteImport.update({
   id: '/',
@@ -33,6 +38,11 @@ const ProjectsPageRoute = ProjectsPageRouteImport.update({
 const OnboardingPageRoute = OnboardingPageRouteImport.update({
   id: '/onboarding/',
   path: '/onboarding/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EventsPageRoute = EventsPageRouteImport.update({
+  id: '/events/',
+  path: '/events/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConfiguracoesPageRoute = ConfiguracoesPageRouteImport.update({
@@ -55,6 +65,16 @@ const ProjectsSlugPageRoute = ProjectsSlugPageRouteImport.update({
   path: '/projects/$slug/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EventsNovoPageRoute = EventsNovoPageRouteImport.update({
+  id: '/events/novo/',
+  path: '/events/novo/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EventsIdPageRoute = EventsIdPageRouteImport.update({
+  id: '/events/$id/',
+  path: '/events/$id/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiUploadsSplatRoute = ApiUploadsSplatRouteImport.update({
   id: '/api/uploads/$',
   path: '/api/uploads/$',
@@ -70,42 +90,67 @@ const ProjectsSlugEditarPageRoute = ProjectsSlugEditarPageRouteImport.update({
   path: '/projects/$slug/editar/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EventsIdRevisaoPageRoute = EventsIdRevisaoPageRouteImport.update({
+  id: '/events/$id/revisao/',
+  path: '/events/$id/revisao/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const EventsIdEditarPageRoute = EventsIdEditarPageRouteImport.update({
+  id: '/events/$id/editar/',
+  path: '/events/$id/editar/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof PageRoute
   '/configuracoes/': typeof ConfiguracoesPageRoute
+  '/events/': typeof EventsPageRoute
   '/onboarding/': typeof OnboardingPageRoute
   '/projects/': typeof ProjectsPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/uploads/$': typeof ApiUploadsSplatRoute
+  '/events/$id/': typeof EventsIdPageRoute
+  '/events/novo/': typeof EventsNovoPageRoute
   '/projects/$slug/': typeof ProjectsSlugPageRoute
   '/projects/novo/': typeof ProjectsNovoPageRoute
   '/u/$username/': typeof UUsernamePageRoute
+  '/events/$id/editar/': typeof EventsIdEditarPageRoute
+  '/events/$id/revisao/': typeof EventsIdRevisaoPageRoute
   '/projects/$slug/editar/': typeof ProjectsSlugEditarPageRoute
 }
 export interface FileRoutesByTo {
   '/': typeof PageRoute
   '/configuracoes': typeof ConfiguracoesPageRoute
+  '/events': typeof EventsPageRoute
   '/onboarding': typeof OnboardingPageRoute
   '/projects': typeof ProjectsPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/uploads/$': typeof ApiUploadsSplatRoute
+  '/events/$id': typeof EventsIdPageRoute
+  '/events/novo': typeof EventsNovoPageRoute
   '/projects/$slug': typeof ProjectsSlugPageRoute
   '/projects/novo': typeof ProjectsNovoPageRoute
   '/u/$username': typeof UUsernamePageRoute
+  '/events/$id/editar': typeof EventsIdEditarPageRoute
+  '/events/$id/revisao': typeof EventsIdRevisaoPageRoute
   '/projects/$slug/editar': typeof ProjectsSlugEditarPageRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof PageRoute
   '/configuracoes/': typeof ConfiguracoesPageRoute
+  '/events/': typeof EventsPageRoute
   '/onboarding/': typeof OnboardingPageRoute
   '/projects/': typeof ProjectsPageRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/uploads/$': typeof ApiUploadsSplatRoute
+  '/events/$id/': typeof EventsIdPageRoute
+  '/events/novo/': typeof EventsNovoPageRoute
   '/projects/$slug/': typeof ProjectsSlugPageRoute
   '/projects/novo/': typeof ProjectsNovoPageRoute
   '/u/$username/': typeof UUsernamePageRoute
+  '/events/$id/editar/': typeof EventsIdEditarPageRoute
+  '/events/$id/revisao/': typeof EventsIdRevisaoPageRoute
   '/projects/$slug/editar/': typeof ProjectsSlugEditarPageRoute
 }
 export interface FileRouteTypes {
@@ -113,50 +158,70 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/configuracoes/'
+    | '/events/'
     | '/onboarding/'
     | '/projects/'
     | '/api/auth/$'
     | '/api/uploads/$'
+    | '/events/$id/'
+    | '/events/novo/'
     | '/projects/$slug/'
     | '/projects/novo/'
     | '/u/$username/'
+    | '/events/$id/editar/'
+    | '/events/$id/revisao/'
     | '/projects/$slug/editar/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/configuracoes'
+    | '/events'
     | '/onboarding'
     | '/projects'
     | '/api/auth/$'
     | '/api/uploads/$'
+    | '/events/$id'
+    | '/events/novo'
     | '/projects/$slug'
     | '/projects/novo'
     | '/u/$username'
+    | '/events/$id/editar'
+    | '/events/$id/revisao'
     | '/projects/$slug/editar'
   id:
     | '__root__'
     | '/'
     | '/configuracoes/'
+    | '/events/'
     | '/onboarding/'
     | '/projects/'
     | '/api/auth/$'
     | '/api/uploads/$'
+    | '/events/$id/'
+    | '/events/novo/'
     | '/projects/$slug/'
     | '/projects/novo/'
     | '/u/$username/'
+    | '/events/$id/editar/'
+    | '/events/$id/revisao/'
     | '/projects/$slug/editar/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   PageRoute: typeof PageRoute
   ConfiguracoesPageRoute: typeof ConfiguracoesPageRoute
+  EventsPageRoute: typeof EventsPageRoute
   OnboardingPageRoute: typeof OnboardingPageRoute
   ProjectsPageRoute: typeof ProjectsPageRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiUploadsSplatRoute: typeof ApiUploadsSplatRoute
+  EventsIdPageRoute: typeof EventsIdPageRoute
+  EventsNovoPageRoute: typeof EventsNovoPageRoute
   ProjectsSlugPageRoute: typeof ProjectsSlugPageRoute
   ProjectsNovoPageRoute: typeof ProjectsNovoPageRoute
   UUsernamePageRoute: typeof UUsernamePageRoute
+  EventsIdEditarPageRoute: typeof EventsIdEditarPageRoute
+  EventsIdRevisaoPageRoute: typeof EventsIdRevisaoPageRoute
   ProjectsSlugEditarPageRoute: typeof ProjectsSlugEditarPageRoute
 }
 
@@ -181,6 +246,13 @@ declare module '@tanstack/react-router' {
       path: '/onboarding'
       fullPath: '/onboarding/'
       preLoaderRoute: typeof OnboardingPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/events/': {
+      id: '/events/'
+      path: '/events'
+      fullPath: '/events/'
+      preLoaderRoute: typeof EventsPageRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/configuracoes/': {
@@ -211,6 +283,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsSlugPageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/events/novo/': {
+      id: '/events/novo/'
+      path: '/events/novo'
+      fullPath: '/events/novo/'
+      preLoaderRoute: typeof EventsNovoPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/events/$id/': {
+      id: '/events/$id/'
+      path: '/events/$id'
+      fullPath: '/events/$id/'
+      preLoaderRoute: typeof EventsIdPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/uploads/$': {
       id: '/api/uploads/$'
       path: '/api/uploads/$'
@@ -232,19 +318,38 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProjectsSlugEditarPageRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/events/$id/revisao/': {
+      id: '/events/$id/revisao/'
+      path: '/events/$id/revisao'
+      fullPath: '/events/$id/revisao/'
+      preLoaderRoute: typeof EventsIdRevisaoPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/events/$id/editar/': {
+      id: '/events/$id/editar/'
+      path: '/events/$id/editar'
+      fullPath: '/events/$id/editar/'
+      preLoaderRoute: typeof EventsIdEditarPageRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   PageRoute: PageRoute,
   ConfiguracoesPageRoute: ConfiguracoesPageRoute,
+  EventsPageRoute: EventsPageRoute,
   OnboardingPageRoute: OnboardingPageRoute,
   ProjectsPageRoute: ProjectsPageRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiUploadsSplatRoute: ApiUploadsSplatRoute,
+  EventsIdPageRoute: EventsIdPageRoute,
+  EventsNovoPageRoute: EventsNovoPageRoute,
   ProjectsSlugPageRoute: ProjectsSlugPageRoute,
   ProjectsNovoPageRoute: ProjectsNovoPageRoute,
   UUsernamePageRoute: UUsernamePageRoute,
+  EventsIdEditarPageRoute: EventsIdEditarPageRoute,
+  EventsIdRevisaoPageRoute: EventsIdRevisaoPageRoute,
   ProjectsSlugEditarPageRoute: ProjectsSlugEditarPageRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/events/$id/editar/page.tsx
+++ b/src/routes/events/$id/editar/page.tsx
@@ -1,0 +1,108 @@
+import {
+	createFileRoute,
+	notFound,
+	redirect,
+	useNavigate,
+} from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
+import { EventForm } from "@/components/event-form";
+import { H1, P } from "@/components/ui/typography";
+import { getEventById, updateEvent } from "@/data/services/event";
+import { getProfileByUserId } from "@/data/services/profile";
+import { getSession } from "@/lib/auth/server";
+
+export const Route = createFileRoute("/events/$id/editar/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (!session) {
+			throw redirect({ to: "/" });
+		}
+		return { session };
+	},
+	loader: async ({ params, context }) => {
+		const event = await getEventById({ data: params.id });
+		if (!event) {
+			throw notFound();
+		}
+
+		const userId = (context as { session: { user: { id: string } } })
+			.session.user.id;
+		const userProfile = await getProfileByUserId({ data: userId });
+		const userRole = userProfile?.role ?? "member";
+
+		const isAuthor = event.submittedBy === userId;
+		const isModAdmin = userRole === "moderator" || userRole === "admin";
+
+		if (!isModAdmin && !(isAuthor && event.status === "rejected")) {
+			throw redirect({ to: "/events/$id", params: { id: params.id } });
+		}
+
+		return { event, userRole, isAuthor };
+	},
+	component: EditEventPage,
+});
+
+function EditEventPage() {
+	const { userRole } = Route.useRouteContext();
+	const { event } = Route.useLoaderData();
+	const navigate = useNavigate();
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const canSetPartner = userRole === "moderator" || userRole === "admin";
+
+	return (
+		<main className="mx-auto w-full max-w-xl px-4 py-24">
+			<div className="mb-8 text-center">
+				<H1>Editar evento</H1>
+				<P className="text-muted-foreground">
+					{event.status === "rejected"
+						? "Corrija o evento e resubmeta para aprovacao."
+						: "Atualize as informacoes do evento."}
+				</P>
+			</div>
+
+			<EventForm
+				mode="edit"
+				canSetPartner={canSetPartner}
+				defaultValues={{
+					name: event.name,
+					description: event.description,
+					date: new Date(event.date),
+					format: event.format as "presencial" | "digital",
+					address: event.address,
+					accessLink: event.accessLink,
+					eventLink: event.eventLink,
+					bannerUrl: event.bannerUrl,
+					organizerName: event.organizerName,
+					isPartner: event.isPartner,
+				}}
+				onSubmit={async (data) => {
+					setIsSubmitting(true);
+					try {
+						await updateEvent({
+							data: { eventId: event.id, updates: data },
+						});
+						toast.success(
+							event.status === "rejected"
+								? "Evento resubmetido para aprovacao"
+								: "Evento atualizado com sucesso",
+						);
+						navigate({
+							to: "/events/$id",
+							params: { id: event.id },
+						});
+					} catch (error) {
+						toast.error(
+							error instanceof Error
+								? error.message
+								: "Erro ao salvar evento",
+						);
+						setIsSubmitting(false);
+					}
+				}}
+				isSubmitting={isSubmitting}
+			/>
+		</main>
+	);
+}

--- a/src/routes/events/$id/page.tsx
+++ b/src/routes/events/$id/page.tsx
@@ -1,0 +1,299 @@
+import {
+	createFileRoute,
+	Link,
+	notFound,
+	useNavigate,
+} from "@tanstack/react-router";
+import { ExternalLink, Eye, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { EventFormatBadge } from "@/components/event-format-badge";
+import { EventPartnerBadge } from "@/components/event-partner-badge";
+import { EventRejectionNotice } from "@/components/event-rejection-notice";
+import { EventStatusBadge } from "@/components/event-status-badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import { H1, Muted, P } from "@/components/ui/typography";
+import { deleteEvent, getEventById } from "@/data/services/event";
+import { getProfileByUserId } from "@/data/services/profile";
+import { authClient } from "@/lib/auth/client";
+import { getSession } from "@/lib/auth/server";
+import { formatEventDateLong } from "@/lib/utils";
+import type { EVENT_FORMATS, EVENT_STATUSES } from "@/lib/validations/event";
+
+export const Route = createFileRoute("/events/$id/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		let userRole = "visitor";
+		if (session) {
+			const userProfile = await getProfileByUserId({
+				data: session.user.id,
+			});
+			userRole = userProfile?.role ?? "member";
+		}
+		return { session, userRole };
+	},
+	loader: async ({ params }) => {
+		const event = await getEventById({ data: params.id });
+		if (!event) {
+			throw notFound();
+		}
+		return { event };
+	},
+	component: EventDetailPage,
+	notFoundComponent: EventNotFound,
+});
+
+function EventNotFound() {
+	return (
+		<main className="mx-auto w-full max-w-2xl px-4 py-24 text-center">
+			<H1>Evento nao encontrado</H1>
+			<P className="text-muted-foreground">
+				O evento que voce procura nao existe ou nao esta disponivel.
+			</P>
+			<Button asChild className="mt-4">
+				<Link to="/events">Voltar para eventos</Link>
+			</Button>
+		</main>
+	);
+}
+
+function EventDetailPage() {
+	const { session, userRole } = Route.useRouteContext();
+	const { event } = Route.useLoaderData();
+	const { data: clientSession } = authClient.useSession();
+	const navigate = useNavigate();
+
+	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+	const [isDeleting, setIsDeleting] = useState(false);
+
+	const currentUserId = session?.user?.id ?? clientSession?.user?.id ?? null;
+	const isAuthor = currentUserId === event.submittedBy;
+	const isModAdmin = userRole === "moderator" || userRole === "admin";
+
+	const handleDelete = async () => {
+		setIsDeleting(true);
+		try {
+			await deleteEvent({ data: event.id });
+			toast.success("Evento excluido com sucesso");
+			navigate({ to: "/events" });
+		} catch {
+			toast.error("Erro ao excluir evento");
+			setIsDeleting(false);
+		}
+	};
+
+	return (
+		<main className="mx-auto w-full max-w-2xl px-4 py-24">
+			{event.bannerUrl && (
+				<div className="mb-6 overflow-hidden rounded-lg">
+					<img
+						src={event.bannerUrl}
+						alt={event.name}
+						className="h-48 w-full object-cover"
+					/>
+				</div>
+			)}
+
+			{event.status !== "approved" && (isAuthor || isModAdmin) && (
+				<div className="mb-4">
+					<EventStatusBadge
+						status={event.status as (typeof EVENT_STATUSES)[number]}
+					/>
+				</div>
+			)}
+
+			<div className="flex items-start gap-4">
+				<div className="flex-1">
+					<H1 className="text-2xl">{event.name}</H1>
+					<p className="mt-1 text-muted-foreground">
+						{formatEventDateLong(new Date(event.date))}
+					</p>
+					<div className="mt-3 flex flex-wrap gap-2">
+						<EventFormatBadge
+							format={event.format as (typeof EVENT_FORMATS)[number]}
+						/>
+						<EventPartnerBadge isPartner={event.isPartner} />
+					</div>
+				</div>
+			</div>
+
+			{(isModAdmin || event.eventLink) && (
+				<div className="mt-4 flex flex-wrap gap-2">
+					{event.eventLink && (
+						<Button variant="outline" size="sm" asChild>
+							<a
+								href={event.eventLink}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<ExternalLink className="size-3.5" />
+								Ver pagina oficial
+							</a>
+						</Button>
+					)}
+					{isModAdmin && (
+						<>
+							<Button variant="outline" size="sm" asChild>
+								<Link
+									to="/events/$id/editar"
+									params={{ id: event.id }}
+								>
+									<Pencil className="size-3.5" />
+									Editar
+								</Link>
+							</Button>
+							{event.status === "pending" && (
+								<Button variant="outline" size="sm" asChild>
+									<Link
+										to="/events/$id/revisao"
+										params={{ id: event.id }}
+									>
+										<Eye className="size-3.5" />
+										Revisar
+									</Link>
+								</Button>
+							)}
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={() => setShowDeleteDialog(true)}
+								className="text-destructive hover:text-destructive"
+							>
+								<Trash2 className="size-3.5" />
+								Excluir
+							</Button>
+						</>
+					)}
+				</div>
+			)}
+
+			{event.description && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Descricao</Muted>
+						<P className="whitespace-pre-wrap">{event.description}</P>
+					</div>
+				</>
+			)}
+
+			{event.format === "presencial" && event.address && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Local</Muted>
+						<P>{event.address}</P>
+					</div>
+				</>
+			)}
+
+			{event.format === "digital" && event.accessLink && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Link de acesso</Muted>
+						<a
+							href={event.accessLink}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-sm text-primary underline"
+						>
+							{event.accessLink}
+						</a>
+					</div>
+				</>
+			)}
+
+			<Separator className="my-6" />
+			<div>
+				<Muted className="mb-3">Organizador</Muted>
+				<P>{event.organizerName}</P>
+			</div>
+
+			{event.submitterProfile && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Submetido por</Muted>
+						<Link
+							to="/u/$username"
+							params={{ username: event.submitterProfile.username }}
+							className="flex items-center gap-3 hover:underline"
+						>
+							<Avatar className="size-8">
+								<AvatarImage
+									src={event.submitterProfile.avatarUrl ?? undefined}
+									alt={event.submitterProfile.username}
+								/>
+								<AvatarFallback className="text-xs">
+									{event.submitterProfile.username[0]?.toUpperCase()}
+								</AvatarFallback>
+							</Avatar>
+							<span className="text-sm">
+								{event.submitterProfile.displayName ??
+									event.submitterProfile.username}
+							</span>
+						</Link>
+					</div>
+				</>
+			)}
+
+			{event.status === "rejected" && isAuthor && (
+				<>
+					<Separator className="my-6" />
+					<EventRejectionNotice
+						rejectionReason={event.rejectionReason}
+						eventId={event.id}
+					/>
+				</>
+			)}
+
+			{!currentUserId && (
+				<div className="mt-8 rounded-lg border bg-muted/50 p-6 text-center">
+					<P className="font-medium">
+						Faca parte da comunidade Indie Hacking Brasil
+					</P>
+					<Muted>
+						Entre para criar e interagir com eventos.
+					</Muted>
+				</div>
+			)}
+
+			<Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Excluir evento</DialogTitle>
+						<DialogDescription>
+							Tem certeza que deseja excluir "{event.name}"? Esta acao nao
+							pode ser desfeita.
+						</DialogDescription>
+					</DialogHeader>
+					<div className="flex justify-end gap-2">
+						<Button
+							variant="outline"
+							onClick={() => setShowDeleteDialog(false)}
+						>
+							Cancelar
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={handleDelete}
+							disabled={isDeleting}
+						>
+							{isDeleting ? "Excluindo..." : "Excluir"}
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</main>
+	);
+}

--- a/src/routes/events/$id/revisao/page.tsx
+++ b/src/routes/events/$id/revisao/page.tsx
@@ -1,0 +1,199 @@
+import {
+	createFileRoute,
+	Link,
+	notFound,
+	redirect,
+	useNavigate,
+} from "@tanstack/react-router";
+import { toast } from "sonner";
+import { EventFormatBadge } from "@/components/event-format-badge";
+import { EventPartnerBadge } from "@/components/event-partner-badge";
+import { EventReviewPanel } from "@/components/event-review-panel";
+import { EventStatusBadge } from "@/components/event-status-badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
+import { H1, Muted, P } from "@/components/ui/typography";
+import {
+	approveEvent,
+	getEventById,
+	rejectEvent,
+} from "@/data/services/event";
+import { getProfileByUserId } from "@/data/services/profile";
+import { getSession } from "@/lib/auth/server";
+import { formatEventDateLong } from "@/lib/utils";
+import type { EVENT_FORMATS, EVENT_STATUSES } from "@/lib/validations/event";
+
+export const Route = createFileRoute("/events/$id/revisao/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (!session) {
+			throw redirect({ to: "/" });
+		}
+
+		const userProfile = await getProfileByUserId({
+			data: session.user.id,
+		});
+		const userRole = userProfile?.role ?? "member";
+
+		if (userRole !== "moderator" && userRole !== "admin") {
+			throw redirect({ to: "/events" });
+		}
+
+		return { session, userRole };
+	},
+	loader: async ({ params }) => {
+		const event = await getEventById({ data: params.id });
+		if (!event) {
+			throw notFound();
+		}
+		return { event };
+	},
+	component: EventReviewPage,
+});
+
+function EventReviewPage() {
+	const { event } = Route.useLoaderData();
+	const navigate = useNavigate();
+
+	const handleApprove = async () => {
+		await approveEvent({ data: event.id });
+		toast.success("Evento aprovado com sucesso");
+		navigate({ to: "/events/$id", params: { id: event.id } });
+	};
+
+	const handleReject = async (reason?: string) => {
+		await rejectEvent({
+			data: { eventId: event.id, reason },
+		});
+		toast.success("Evento rejeitado");
+		navigate({ to: "/events" });
+	};
+
+	return (
+		<main className="mx-auto w-full max-w-2xl px-4 py-24">
+			<div className="mb-6">
+				<Muted className="mb-2">Revisao de evento</Muted>
+				<H1 className="text-2xl">Revisar: {event.name}</H1>
+			</div>
+
+			<EventStatusBadge
+				status={event.status as (typeof EVENT_STATUSES)[number]}
+			/>
+
+			{event.bannerUrl && (
+				<div className="mt-4 overflow-hidden rounded-lg">
+					<img
+						src={event.bannerUrl}
+						alt={event.name}
+						className="h-48 w-full object-cover"
+					/>
+				</div>
+			)}
+
+			<Separator className="my-6" />
+
+			<div className="space-y-4">
+				<div>
+					<Muted>Data e horario</Muted>
+					<P>{formatEventDateLong(new Date(event.date))}</P>
+				</div>
+
+				<div className="flex flex-wrap gap-2">
+					<EventFormatBadge
+						format={event.format as (typeof EVENT_FORMATS)[number]}
+					/>
+					<EventPartnerBadge isPartner={event.isPartner} />
+				</div>
+
+				{event.description && (
+					<div>
+						<Muted>Descricao</Muted>
+						<P className="whitespace-pre-wrap">{event.description}</P>
+					</div>
+				)}
+
+				{event.format === "presencial" && event.address && (
+					<div>
+						<Muted>Local</Muted>
+						<P>{event.address}</P>
+					</div>
+				)}
+
+				{event.format === "digital" && event.accessLink && (
+					<div>
+						<Muted>Link de acesso</Muted>
+						<a
+							href={event.accessLink}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-sm text-primary underline"
+						>
+							{event.accessLink}
+						</a>
+					</div>
+				)}
+
+				{event.eventLink && (
+					<div>
+						<Muted>Pagina oficial</Muted>
+						<a
+							href={event.eventLink}
+							target="_blank"
+							rel="noopener noreferrer"
+							className="text-sm text-primary underline"
+						>
+							{event.eventLink}
+						</a>
+					</div>
+				)}
+
+				<div>
+					<Muted>Organizador</Muted>
+					<P>{event.organizerName}</P>
+				</div>
+			</div>
+
+			{event.submitterProfile && (
+				<>
+					<Separator className="my-6" />
+					<div>
+						<Muted className="mb-3">Submetido por</Muted>
+						<Link
+							to="/u/$username"
+							params={{
+								username: event.submitterProfile.username,
+							}}
+							className="flex items-center gap-3 hover:underline"
+						>
+							<Avatar className="size-8">
+								<AvatarImage
+									src={
+										event.submitterProfile.avatarUrl ?? undefined
+									}
+									alt={event.submitterProfile.username}
+								/>
+								<AvatarFallback className="text-xs">
+									{event.submitterProfile.username[0]?.toUpperCase()}
+								</AvatarFallback>
+							</Avatar>
+							<span className="text-sm">
+								{event.submitterProfile.displayName ??
+									event.submitterProfile.username}
+							</span>
+						</Link>
+					</div>
+				</>
+			)}
+
+			{event.status === "pending" && (
+				<>
+					<Separator className="my-6" />
+					<EventReviewPanel
+						onApprove={handleApprove}
+						onReject={handleReject}
+					/>
+				</>
+			)}
+		</main>
+	);
+}

--- a/src/routes/events/novo/page.tsx
+++ b/src/routes/events/novo/page.tsx
@@ -1,0 +1,70 @@
+import {
+	createFileRoute,
+	redirect,
+	useNavigate,
+} from "@tanstack/react-router";
+import { useState } from "react";
+import { EventForm } from "@/components/event-form";
+import { H1, P } from "@/components/ui/typography";
+import { createEvent } from "@/data/services/event";
+import { getProfileByUserId } from "@/data/services/profile";
+import { getSession } from "@/lib/auth/server";
+
+export const Route = createFileRoute("/events/novo/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		if (!session) {
+			throw redirect({ to: "/" });
+		}
+
+		const userProfile = await getProfileByUserId({
+			data: session.user.id,
+		});
+		if (!userProfile?.isOnboardingComplete) {
+			throw redirect({ to: "/onboarding" });
+		}
+
+		return { session, userProfile };
+	},
+	component: NewEventPage,
+});
+
+function NewEventPage() {
+	const { userProfile } = Route.useRouteContext();
+	const navigate = useNavigate();
+	const [isSubmitting, setIsSubmitting] = useState(false);
+
+	const canSetPartner =
+		userProfile.role === "moderator" || userProfile.role === "admin";
+
+	return (
+		<main className="mx-auto w-full max-w-xl px-4 py-24">
+			<div className="mb-8 text-center">
+				<H1>Criar evento</H1>
+				<P className="text-muted-foreground">
+					Submeta um evento para a comunidade. Ele sera revisado antes de
+					ser publicado.
+				</P>
+			</div>
+
+			<EventForm
+				mode="create"
+				canSetPartner={canSetPartner}
+				onSubmit={async (data) => {
+					setIsSubmitting(true);
+					try {
+						const result = await createEvent({ data });
+						navigate({
+							to: "/events/$id",
+							params: { id: result.id },
+						});
+					} catch (error) {
+						setIsSubmitting(false);
+						throw error;
+					}
+				}}
+				isSubmitting={isSubmitting}
+			/>
+		</main>
+	);
+}

--- a/src/routes/events/page.tsx
+++ b/src/routes/events/page.tsx
@@ -1,0 +1,185 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Calendar, Plus } from "lucide-react";
+import { EventCard } from "@/components/event-card";
+import { Button } from "@/components/ui/button";
+import { Empty, EmptyDescription, EmptyTitle } from "@/components/ui/empty";
+import { H1, Muted, P } from "@/components/ui/typography";
+import { listEvents } from "@/data/services/event";
+import { authClient } from "@/lib/auth/client";
+import { getSession } from "@/lib/auth/server";
+import type { EVENT_FORMATS, EVENT_STATUSES } from "@/lib/validations/event";
+
+export const Route = createFileRoute("/events/")({
+	beforeLoad: async () => {
+		const session = await getSession();
+		return { session };
+	},
+	loader: async () => {
+		const result = await listEvents();
+		return { result };
+	},
+	component: EventsPage,
+});
+
+function EventsPage() {
+	const { session } = Route.useRouteContext();
+	const { result } = Route.useLoaderData();
+	const { data: clientSession } = authClient.useSession();
+
+	const isAuthenticated = !!session || !!clientSession;
+	const isModerator =
+		result.requesterRole === "moderator" ||
+		result.requesterRole === "admin";
+
+	const hasEvents =
+		result.pending.length > 0 ||
+		result.upcoming.length > 0 ||
+		result.past.length > 0;
+
+	return (
+		<main className="mx-auto w-full max-w-6xl px-4 py-24">
+			<div className="mb-8 flex items-center justify-between">
+				<div>
+					<H1 className="text-2xl">Eventos</H1>
+					<P className="text-muted-foreground">
+						Descubra eventos da comunidade e parceiros
+					</P>
+				</div>
+				{isAuthenticated && (
+					<Button asChild>
+						<Link to="/events/novo">
+							<Plus className="size-4" />
+							Criar evento
+						</Link>
+					</Button>
+				)}
+			</div>
+
+			{isModerator && result.pending.length > 0 && (
+				<section className="mb-8">
+					<div className="mb-4 flex items-center gap-2">
+						<h2 className="text-lg font-semibold">Fila de aprovacao</h2>
+						<span className="rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400">
+							{result.pending.length}
+						</span>
+					</div>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{result.pending.map((event) => (
+							<EventCard
+								key={event.id}
+								id={event.id}
+								name={event.name}
+								date={new Date(event.date)}
+								format={event.format as (typeof EVENT_FORMATS)[number]}
+								organizerName={event.organizerName}
+								isPartner={event.isPartner}
+								status={event.status as (typeof EVENT_STATUSES)[number]}
+								showStatus
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{result.rejected.length > 0 && (
+				<section className="mb-8">
+					<h2 className="mb-4 text-lg font-semibold">Seus eventos rejeitados</h2>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{result.rejected.map((event) => (
+							<EventCard
+								key={event.id}
+								id={event.id}
+								name={event.name}
+								date={new Date(event.date)}
+								format={event.format as (typeof EVENT_FORMATS)[number]}
+								organizerName={event.organizerName}
+								isPartner={event.isPartner}
+								status={event.status as (typeof EVENT_STATUSES)[number]}
+								showStatus
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{result.upcoming.length > 0 && (
+				<section className="mb-8">
+					<h2 className="mb-4 text-lg font-semibold">Proximos eventos</h2>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{result.upcoming.map((event) => (
+							<EventCard
+								key={event.id}
+								id={event.id}
+								name={event.name}
+								date={new Date(event.date)}
+								format={event.format as (typeof EVENT_FORMATS)[number]}
+								organizerName={event.organizerName}
+								isPartner={event.isPartner}
+								status={
+									isModerator
+										? (event.status as (typeof EVENT_STATUSES)[number])
+										: undefined
+								}
+								showStatus={isModerator}
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{result.past.length > 0 && (
+				<section className="mb-8">
+					<h2 className="mb-4 text-lg font-semibold">Eventos passados</h2>
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{result.past.map((event) => (
+							<EventCard
+								key={event.id}
+								id={event.id}
+								name={event.name}
+								date={new Date(event.date)}
+								format={event.format as (typeof EVENT_FORMATS)[number]}
+								organizerName={event.organizerName}
+								isPartner={event.isPartner}
+								status={
+									isModerator
+										? (event.status as (typeof EVENT_STATUSES)[number])
+										: undefined
+								}
+								showStatus={isModerator}
+							/>
+						))}
+					</div>
+				</section>
+			)}
+
+			{!hasEvents && (
+				<Empty>
+					<Calendar className="mx-auto mb-2 size-10 text-muted-foreground" />
+					<EmptyTitle>Nenhum evento encontrado</EmptyTitle>
+					<EmptyDescription>
+						Seja o primeiro a divulgar um evento da comunidade!
+					</EmptyDescription>
+					{isAuthenticated && (
+						<Button asChild className="mt-4">
+							<Link to="/events/novo">
+								<Plus className="size-4" />
+								Criar evento
+							</Link>
+						</Button>
+					)}
+				</Empty>
+			)}
+
+			{!isAuthenticated && (
+				<div className="mt-8 rounded-lg border bg-muted/50 p-6 text-center">
+					<P className="font-medium">
+						Faca parte da comunidade Indie Hacking Brasil
+					</P>
+					<Muted>
+						Entre para criar e divulgar eventos.
+					</Muted>
+				</div>
+			)}
+		</main>
+	);
+}


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Indie Hacking Brasil platform: a complete events management system with submission, moderation, and approval workflow. Members can submit events that are reviewed by moderators/admins before publication to the community.

## Key Changes

- Database schema with `events` and `eventMembers` tables supporting presencial/digital formats, organizer info, and approval tracking
- 8 server functions covering CRUD operations, event approval/rejection, and access-controlled queries
- 6 reusable React components for event cards, forms, status badges, and review panels
- 5 new routes with role-based access control: listing, creation, detail view, editing, and moderation review
- Date formatting utilities and validation schemas with conditional field requirements

## Workflow

1. Members complete onboarding and visit `/events/novo` to submit events
2. Moderators/admins see pending events in the approval queue at `/events`
3. Admins review events at `/events/$id/revisao` and approve or reject
4. Approved events appear in "Próximos eventos" and "Eventos passados" sections
5. Rejected events can be re-edited by authors and resubmitted

Full implementation follows the plan at `src/docs/funcionalidades/03-eventos.md` and reuses existing patterns from the projects feature.